### PR TITLE
Fixes #99: use impossible name for relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Aqua
 
+[![release](https://github.com/fluencelabs/aqua/actions/workflows/release.yml/badge.svg)](https://github.com/fluencelabs/aqua/actions/workflows/release.yml)
+
 Aqua is a new-gen language for distributed systems.
 
 Aqua programs are executed on many peers, sequentially 

--- a/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
+++ b/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
@@ -58,7 +58,7 @@ case class TypescriptFunc(func: FuncCallable) {
        |            `,
        |            )
        |            .configHandler((h) => {
-       |                h.on('${conf.getDataService}', 'relay', () => {
+       |                h.on('${conf.getDataService}', '${conf.relayVarName}', () => {
        |                    return client.relayPeerId!;
        |                });
        |                h.on('getRelayService', 'hasRelay', () => {// Not Used

--- a/model/src/main/scala/aqua/model/transform/BodyConfig.scala
+++ b/model/src/main/scala/aqua/model/transform/BodyConfig.scala
@@ -8,7 +8,7 @@ case class BodyConfig(
   errorHandlingService: String = "errorHandlingSrv",
   errorFuncName: String = "error",
   respFuncName: String = "response",
-  relayVarName: String = "relay",
+  relayVarName: String = "-relay-",
   wrapWithXor: Boolean = true
 ) {
 

--- a/model/src/test/scala/aqua/model/Node.scala
+++ b/model/src/test/scala/aqua/model/Node.scala
@@ -84,8 +84,8 @@ object Node {
   implicit def nodeToCof(tree: Node): Cof =
     Cofree(tree.tag, Eval.later(Chain.fromSeq(tree.ops.map(nodeToCof))))
 
-  val relay = LiteralModel("relay")
-  val relayV = VarModel("relay", ScalarType.string)
+  val relay = LiteralModel("-relay-")
+  val relayV = VarModel("-relay-", ScalarType.string)
   val initPeer = LiteralModel.initPeerId
   val emptyCall = Call(Nil, None)
   val otherPeer = LiteralModel("other-peer")

--- a/model/src/test/scala/aqua/model/transform/TransformSpec.scala
+++ b/model/src/test/scala/aqua/model/transform/TransformSpec.scala
@@ -33,7 +33,7 @@ class TransformSpec extends AnyFlatSpec with Matchers {
     val expectedFC =
       xor(
         seq(
-          dataCall(bc, "relay", initPeer),
+          dataCall(bc, "-relay-", initPeer),
           through(relayV),
           call(1, otherPeer),
           through(relayV),
@@ -71,7 +71,7 @@ class TransformSpec extends AnyFlatSpec with Matchers {
     val expectedFC =
       xor(
         seq(
-          dataCall(bc, "relay", initPeer),
+          dataCall(bc, "-relay-", initPeer),
           call(0, initPeer),
           through(relayV),
           call(1, otherPeer),
@@ -136,7 +136,7 @@ class TransformSpec extends AnyFlatSpec with Matchers {
 
     res.equalsOrPrintDiff(
       seq(
-        dataCall(bc, "relay", initPeer),
+        dataCall(bc, "-relay-", initPeer),
         Node(
           CallServiceTag(
             LiteralModel("\"srv1\""),


### PR DESCRIPTION
Fldist might need to be changed. Relay name is a part of the configuration in `BodyConfig`, will be configurable with #76 