### PR TITLE
Config options to omit xor wrapper, relay passing

### DIFF
--- a/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
+++ b/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
@@ -58,12 +58,11 @@ case class TypescriptFunc(func: FuncCallable) {
        |            `,
        |            )
        |            .configHandler((h) => {
-       |                h.on('${conf.getDataService}', 'relay', () => {
+       |                ${conf.relayVarName.fold("") { r =>
+      s"""h.on('${conf.getDataService}', '$r', () => {
        |                    return client.relayPeerId!;
-       |                });
-       |                h.on('getRelayService', 'hasRelay', () => {// Not Used
-       |                    return client.relayPeerId !== undefined;
-       |                });
+       |                });""".stripMargin
+    }}
        |                $setCallbacks
        |                ${returnCallback.getOrElse("")}
        |                h.onEvent('${conf.errorHandlingService}', '${conf.errorFuncName}', (args) => {

--- a/model/src/main/scala/aqua/model/transform/BodyConfig.scala
+++ b/model/src/main/scala/aqua/model/transform/BodyConfig.scala
@@ -8,7 +8,7 @@ case class BodyConfig(
   errorHandlingService: String = "errorHandlingSrv",
   errorFuncName: String = "error",
   respFuncName: String = "response",
-  relayVarName: String = "relay",
+  relayVarName: Option[String] = Some("relay"),
   wrapWithXor: Boolean = true
 ) {
 

--- a/model/src/main/scala/aqua/model/transform/Transform.scala
+++ b/model/src/main/scala/aqua/model/transform/Transform.scala
@@ -12,7 +12,7 @@ object Transform {
 
   def forClient(func: FuncCallable, conf: BodyConfig): Cofree[Chain, OpTag] = {
     val initCallable: InitPeerCallable = InitViaRelayCallable(
-      Chain.one(VarModel(conf.relayVarName, ScalarType.string))
+      Chain.fromOption(conf.relayVarName).map(VarModel(_, ScalarType.string))
     )
     val errorsCatcher = ErrorsCatcher(
       enabled = conf.wrapWithXor,
@@ -23,8 +23,8 @@ object Transform {
     val argsProvider: ArgsProvider =
       ArgsFromService(
         conf.dataSrvId,
-        conf.relayVarName -> ScalarType.string :: func.args.dataArgs.toList.map(add =>
-          add.name -> add.dataType
+        conf.relayVarName.map(_ -> ScalarType.string).toList ::: func.args.dataArgs.toList.map(
+          add => add.name -> add.dataType
         )
       )
 


### PR DESCRIPTION
Fixes #67 : to compile for scripts storage, use CLI with `--no-xor --no-relay --air` flags and take a function with no arguments.

Should be further improved, but fills the hole right now.

Starting with this version, `aqua` can target Typescript, fldist, and script storage on nodes.