### PR TITLE
Wrap every OnTag (topological shift) with Xor

### DIFF
--- a/model/src/main/scala/aqua/model/func/body/FuncOps.scala
+++ b/model/src/main/scala/aqua/model/func/body/FuncOps.scala
@@ -34,15 +34,17 @@ object FuncOps {
     )
 
   def seq(ops: FuncOp*): FuncOp =
-    FuncOp.node(
-      SeqTag,
-      Chain
-        .fromSeq(ops.flatMap {
-          case FuncOp(Cofree(SeqTag, subOps)) => subOps.value.toList
-          case FuncOp(cof) => cof :: Nil
-        })
-        .map(FuncOp(_))
-    )
+    if (ops.length == 1) ops.head
+    else
+      FuncOp.node(
+        SeqTag,
+        Chain
+          .fromSeq(ops.flatMap {
+            case FuncOp(Cofree(SeqTag, subOps)) => subOps.value.toList
+            case FuncOp(cof) => cof :: Nil
+          })
+          .map(FuncOp(_))
+      )
 
   def xor(left: FuncOp, right: FuncOp): FuncOp =
     FuncOp.node(XorTag, Chain(left, right))

--- a/model/src/main/scala/aqua/model/transform/Transform.scala
+++ b/model/src/main/scala/aqua/model/transform/Transform.scala
@@ -29,7 +29,7 @@ object Transform {
       )
 
     val transform =
-      errorsCatcher.transform _ compose initCallable.transform compose argsProvider.transform
+      initCallable.transform _ compose argsProvider.transform
 
     val callback = initCallable.service(conf.callbackSrvId)
 
@@ -39,6 +39,12 @@ object Transform {
       conf.respFuncName
     )
 
-    Topology.resolve(wrapFunc.resolve(func).value.tree)
+    Topology.resolve(
+      errorsCatcher
+        .transform(
+          wrapFunc.resolve(func).value
+        )
+        .tree
+    )
   }
 }

--- a/model/src/test/scala/aqua/model/Node.scala
+++ b/model/src/test/scala/aqua/model/Node.scala
@@ -97,11 +97,11 @@ object Node {
     CallServiceTag(LiteralModel(s"srv$i"), s"fn$i", Call(Nil, None), Option(on))
   )
 
-  def xorErrorCall(bc: BodyConfig, on: ValueModel = null) = Node(
+  def errorCall(bc: BodyConfig, i: Int, on: ValueModel = null) = Node(
     CallServiceTag(
       bc.errorHandlingCallback,
       bc.errorFuncName,
-      Call(LiteralModel("%last_error%") :: Nil, None),
+      Call(LiteralModel("%last_error%") :: LiteralModel(i.toString) :: Nil, None),
       Option(on)
     )
   )


### PR DESCRIPTION
Helps with getting back with error from every node.

Might need further improvement:

- Fire-and-forget semantics, when we have it, means that we don't want to get errors back
- Error handling might provide unnecessary/inefficient hops

These improvements are mostly topological and are affected by #102.