### PR TITLE
Try expression added

### DIFF
--- a/aqua-src/error.aqua
+++ b/aqua-src/error.aqua
@@ -19,5 +19,9 @@ func betterMessage(relay: string):
         par isOnline <- Peer.is_connected(relay)
     par on "quray":
         Peer.is_connected("qurara")
+
     if isOnline:
+      try:
         Test.doSomething()
+    else:
+      Peer.is_connected("else")

--- a/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
@@ -40,21 +40,18 @@ object AirGen {
     case list => list.reduceLeft(SeqGen)
   }
 
-  def wrapMatchWithXor(ag: AirGen): AirGen = ag match {
-    case mmg: MatchMismatchGen =>
-      XorGen(mmg, NullGen)
-    case g => g
-  }
-
   def apply(op: Cofree[Chain, OpTag]): AirGen =
     Cofree
       .cata[Chain, OpTag, AirGen](op) {
         case (SeqTag, ops) =>
-          Eval later ops.map(wrapMatchWithXor).toList.reduceLeftOption(SeqGen).getOrElse(NullGen)
+          Eval later ops.toList.reduceLeftOption(SeqGen).getOrElse(NullGen)
         case (ParTag, ops) =>
-          Eval later ops.map(wrapMatchWithXor).toList.reduceLeftOption(ParGen).getOrElse(NullGen)
+          Eval later ops.toList.reduceLeftOption(ParGen).getOrElse(NullGen)
         case (XorTag, ops) =>
           Eval later ops.toList.reduceLeftOption(XorGen).getOrElse(NullGen)
+        case (XorTag.LeftBiased, ops) =>
+          Eval later XorGen(opsToSingle(ops), NullGen)
+
         case (NextTag(item), _) =>
           Eval later NextGen(item)
         case (MatchMismatchTag(left, right, shouldMatch), ops) =>
@@ -66,7 +63,7 @@ object AirGen {
           )
 
         case (ForTag(item, iterable), ops) =>
-          Eval later ForGen(valueToData(iterable), item, opsToSingle(ops.map(wrapMatchWithXor)))
+          Eval later ForGen(valueToData(iterable), item, opsToSingle(ops))
         case (CallServiceTag(serviceId, funcName, Call(args, exportTo), peerId), _) =>
           Eval.later(
             ServiceCallGen(

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val declineEnumV = "1.3.0"
 name := "aqua-hll"
 
 val commons = Seq(
-  baseAquaVersion := "0.1.1",
+  baseAquaVersion := "0.1.2",
   version         := baseAquaVersion.value + "-" + sys.env.getOrElse("BUILD_NUMBER", "SNAPSHOT"),
   scalaVersion    := dottyVersion,
   libraryDependencies ++= Seq(

--- a/model/src/main/scala/aqua/model/func/body/FuncOp.scala
+++ b/model/src/main/scala/aqua/model/func/body/FuncOp.scala
@@ -74,7 +74,10 @@ object FuncOp {
 
     override def combine(x: FuncOp, y: FuncOp): FuncOp = (x.tree.head, y.tree.head) match {
       case (ParTag, ParTag) => FuncOp(y.tree.copy(tail = (x.tree.tail, y.tree.tail).mapN(_ ++ _)))
-      case (XorTag, XorTag) => FuncOp(y.tree.copy(tail = (x.tree.tail, y.tree.tail).mapN(_ ++ _)))
+      case (XorTag, XorTag) =>
+        FuncOp(y.tree.copy(tail = (x.tree.tail, y.tree.tail).mapN(_ ++ _)))
+      case (XorTag.LeftBiased, XorTag) =>
+        wrap(SeqTag, FuncOp(y.tree.copy(tail = (x.tree.tail, y.tree.tail).mapN(_ ++ _))))
       case (XorTag, ParTag) => FuncOp(Cofree[Chain, OpTag](XorParTag(x, y), Eval.now(Chain.empty)))
       case (_, ParTag | XorTag) =>
         wrap(SeqTag, FuncOp(y.tree.copy(tail = y.tree.tail.map(_.prepend(x.tree)))))

--- a/model/src/main/scala/aqua/model/func/body/OpTag.scala
+++ b/model/src/main/scala/aqua/model/func/body/OpTag.scala
@@ -32,7 +32,10 @@ sealed trait SeqGroupTag extends GroupTag
 
 case object SeqTag extends SeqGroupTag
 case object ParTag extends GroupTag
-case object XorTag extends GroupTag
+
+case object XorTag extends GroupTag {
+  case object LeftBiased extends GroupTag
+}
 case class XorParTag(xor: FuncOp, par: FuncOp) extends OpTag
 case class OnTag(peerId: ValueModel, via: Chain[ValueModel]) extends SeqGroupTag
 case class NextTag(item: String) extends OpTag

--- a/parser/src/main/scala/aqua/parser/expr/ForExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/ForExpr.scala
@@ -25,6 +25,7 @@ object ForExpr extends Expr.AndIndented {
       Expr.defer(ForExpr) ::
       CallArrowExpr ::
       AbilityIdExpr ::
+      Expr.defer(TryExpr) ::
       Expr.defer(IfExpr) ::
       Expr.defer(ElseOtherwiseExpr) ::
       Nil

--- a/parser/src/main/scala/aqua/parser/expr/FuncExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/FuncExpr.scala
@@ -25,6 +25,7 @@ object FuncExpr extends Expr.AndIndented {
       Expr.defer(OnExpr) ::
       CallArrowExpr ::
       IfExpr ::
+      TryExpr ::
       ElseOtherwiseExpr ::
       ParExpr ::
       DeclareStreamExpr ::

--- a/parser/src/main/scala/aqua/parser/expr/IfExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/IfExpr.scala
@@ -16,6 +16,7 @@ object IfExpr extends Expr.AndIndented {
     Expr.defer(OnExpr) ::
       CallArrowExpr ::
       AbilityIdExpr ::
+      Expr.defer(TryExpr) ::
       Expr.defer(ForExpr) ::
       Expr.defer(IfExpr) ::
       Expr.defer(ElseOtherwiseExpr) ::

--- a/parser/src/main/scala/aqua/parser/expr/OnExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/OnExpr.scala
@@ -16,6 +16,7 @@ object OnExpr extends Expr.AndIndented {
       CallArrowExpr ::
       AbilityIdExpr ::
       ParExpr ::
+      Expr.defer(TryExpr) ::
       Expr.defer(ForExpr) ::
       Expr.defer(IfExpr) ::
       Expr.defer(ElseOtherwiseExpr) ::

--- a/parser/src/main/scala/aqua/parser/expr/TryExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/TryExpr.scala
@@ -1,0 +1,19 @@
+package aqua.parser.expr
+
+import aqua.parser.Expr
+import aqua.parser.lexer.Token._
+import aqua.parser.lift.LiftParser
+import aqua.parser.lift.LiftParser._
+import cats.Comonad
+import cats.parse.{Parser => P}
+
+case class TryExpr[F[_]](point: F[Unit]) extends Expr[F](TryExpr)
+
+object TryExpr extends Expr.AndIndented {
+
+  override def validChildren: List[Expr.Lexem] =
+    IfExpr.validChildren
+
+  override def p[F[_]: LiftParser: Comonad]: P[TryExpr[F]] =
+    `try`.lift.map(TryExpr(_))
+}

--- a/semantics/src/main/scala/aqua/semantics/ExprSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/ExprSem.scala
@@ -30,6 +30,7 @@ object ExprSem {
       case expr: OnExpr[F] => new OnSem(expr).program[G]
       case expr: ForExpr[F] => new ForSem(expr).program[G]
       case expr: IfExpr[F] => new IfSem(expr).program[G]
+      case expr: TryExpr[F] => new TrySem(expr).program[G]
       case expr: ElseOtherwiseExpr[F] => new ElseOtherwiseSem(expr).program[G]
       case expr: ParExpr[F] => new ParSem(expr).program[G]
       case expr: ReturnExpr[F] => new ReturnSem(expr).program[G]

--- a/semantics/src/main/scala/aqua/semantics/expr/IfSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/IfSem.scala
@@ -1,7 +1,7 @@
 package aqua.semantics.expr
 
 import aqua.model.Model
-import aqua.model.func.body.{FuncOp, MatchMismatchTag}
+import aqua.model.func.body.{FuncOp, MatchMismatchTag, XorTag}
 import aqua.parser.expr.IfExpr
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
@@ -36,12 +36,15 @@ class IfSem[F[_]](val expr: IfExpr[F]) extends AnyVal {
               case op: FuncOp =>
                 Free.pure[Alg, Model](
                   FuncOp.wrap(
-                    MatchMismatchTag(
-                      ValuesAlgebra.valueToModel(expr.left, lt),
-                      ValuesAlgebra.valueToModel(expr.right, rt),
-                      expr.eqOp.value
-                    ),
-                    op
+                    XorTag.LeftBiased,
+                    FuncOp.wrap(
+                      MatchMismatchTag(
+                        ValuesAlgebra.valueToModel(expr.left, lt),
+                        ValuesAlgebra.valueToModel(expr.right, rt),
+                        expr.eqOp.value
+                      ),
+                      op
+                    )
                   )
                 )
               case _ => Free.pure[Alg, Model](Model.error("Wrong body of the if expression"))

--- a/semantics/src/main/scala/aqua/semantics/expr/TrySem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/TrySem.scala
@@ -1,0 +1,25 @@
+package aqua.semantics.expr
+
+import aqua.model.Model
+import aqua.model.func.body.{FuncOp, XorTag}
+import aqua.parser.expr.TryExpr
+import aqua.semantics.Prog
+import aqua.semantics.rules.ValuesAlgebra
+import aqua.semantics.rules.types.TypesAlgebra
+import cats.free.Free
+
+class TrySem[F[_]](val expr: TryExpr[F]) extends AnyVal {
+
+  def program[Alg[_]](implicit
+    V: ValuesAlgebra[F, Alg],
+    T: TypesAlgebra[F, Alg]
+  ): Prog[Alg, Model] =
+    Prog.after[Alg, Model] {
+      case o: FuncOp =>
+        Free.pure[Alg, Model](
+          FuncOp.wrap(XorTag.LeftBiased, o)
+        )
+      case _ =>
+        Free.pure[Alg, Model](Model.error("Wrong body of the try expression"))
+    }
+}


### PR DESCRIPTION
Related to #28 (no catch syntax yet).

Now you can use `try` this way:

```python

try:
  Op.identity()

```

If the block fails, it will not affect execution. If you want to recover, use `otherwise`:

```python

try:
  Op.identity()
otherwise:
  on smth:
     Op.identity()

```