### PR TITLE
Add a button for creating releases manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
         run: |
           set -x
           if [ "${{ github.event.inputs.release }}" = "true" ]; then
-            echo "DRAFT='false'" >> $GITHUB_ENV
+            echo "DRAFT=false" >> $GITHUB_ENV
           else
-            echo "DRAFT='true'" >> $GITHUB_ENV
+            echo "DRAFT=true" >> $GITHUB_ENV
           fi
 
       ### create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,16 @@ on:
     # uncomment to release only on tags starting with 'v'
     # tags:
     #   - "v*"
-    branches:
-      - "main"
+    # branches:
+    #   - "main"
 
   workflow_dispatch:
     inputs:
-      draft:
-        description: "Whether to create draft or actual release. 'false' by default, put 'true' to make draft release"
+      release:
+        description: "Drafted or public release?
+        Public is the default, put 'false' to make a draft release"
         required: false
-        default: false
+        default: 'true'
 
 jobs:
   release:
@@ -63,24 +64,33 @@ jobs:
           echo "JAR=$JAR" >> $GITHUB_ENV
 
       ### Publish to NPM registry
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "14"
-          registry-url: "https://registry.npmjs.org"
+      # - uses: actions/setup-node@v1
+      #   with:
+      #     node-version: "14"
+      #     registry-url: "https://registry.npmjs.org"
 
-      - name: Install jq and prepare package
+      # - name: Install jq and prepare package
+      #   run: |
+      #     sudo apt-get update && sudo apt-get --yes --force-yes install jq
+      #     PKG_NAME="$(cat package.json | jq -r .name)"
+      #     cp ${{ env.JAR }} ./npm/aqua-cli.jar
+
+      # - run: npm version ${{ env.VERSION }}
+      #   working-directory: ./npm
+
+      # - run: npm publish --access public
+      #   working-directory: ./npm
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: determine if release should be drafted
         run: |
-          sudo apt-get update && sudo apt-get --yes --force-yes install jq
-          PKG_NAME="$(cat package.json | jq -r .name)"
-          cp ${{ env.JAR }} ./npm/aqua-cli.jar
-
-      - run: npm version ${{ env.VERSION }}
-        working-directory: ./npm
-
-      - run: npm publish --access public
-        working-directory: ./npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          set -x
+          if [ "${{ github.event.inputs.release }}" = "true" ]; then
+            echo "export DRAFT=false" >> $GITHUB_ENV
+          else
+            echo "export DRAFT=true" >> $GITHUB_ENV
+          fi
 
       ### create release
       - uses: marvinpinto/action-automatic-releases@latest
@@ -94,6 +104,6 @@ jobs:
             ${{ env.JAR }}
           body: |
             [${{ env.VERSION }} @ NPM registry](https://www.npmjs.com/package/${{ env.PKG_NAME }}/v/${{ env.VERSION }})
-          draft: true #${{ github.event.inputs.draft }}
+          draft: ${{ env.DRAFT }}
           prerelease: false
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
         run: |
           set -x
           if [ "${{ github.event.inputs.release }}" = "true" ]; then
-            echo "export DRAFT=false" >> $GITHUB_ENV
+            echo "export DRAFT='false'" >> $GITHUB_ENV
           else
-            echo "export DRAFT=true" >> $GITHUB_ENV
+            echo "export DRAFT='true'" >> $GITHUB_ENV
           fi
 
       ### create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,15 @@ on:
     # uncomment to release only on tags starting with 'v'
     # tags:
     #   - "v*"
-    # branches:
-    #   - "main"
+    branches:
+      - "main"
 
   workflow_dispatch:
     inputs:
       release:
-        description: "Drafted or public release?
-        Public is the default, put 'false' to make a draft release"
+        description: "Draft or public release?\nPut 'draft' to make a draft release"
         required: false
-        default: 'true'
+        default: 'public'
 
 jobs:
   release:
@@ -29,10 +28,10 @@ jobs:
       - uses: olafurpg/setup-scala@v10
 
       ### Update & build
-      # - name: Assembly
-      #   run: sbt cli/assembly
-      #   env:
-      #     BUILD_NUMBER: ${{ github.run_number }}
+      - name: Assembly
+        run: sbt cli/assembly
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
 
       ### Create release
       - name: Get project version
@@ -57,36 +56,36 @@ jobs:
         env:
           BUILD_NUMBER: ${{ github.run_number }}
 
-      # - name: Check .jar exists
-      #   run: |
-      #     JAR="cli/target/scala-2.13/aqua-cli-${{ env.VERSION }}.jar"
-      #     stat "$JAR"
-      #     echo "JAR=$JAR" >> $GITHUB_ENV
+      - name: Check .jar exists
+        run: |
+          JAR="cli/target/scala-2.13/aqua-cli-${{ env.VERSION }}.jar"
+          stat "$JAR"
+          echo "JAR=$JAR" >> $GITHUB_ENV
 
       ### Publish to NPM registry
-      # - uses: actions/setup-node@v1
-      #   with:
-      #     node-version: "14"
-      #     registry-url: "https://registry.npmjs.org"
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14"
+          registry-url: "https://registry.npmjs.org"
 
-      # - name: Install jq and prepare package
-      #   run: |
-      #     sudo apt-get update && sudo apt-get --yes --force-yes install jq
-      #     PKG_NAME="$(cat package.json | jq -r .name)"
-      #     cp ${{ env.JAR }} ./npm/aqua-cli.jar
+      - name: Install jq and prepare package
+        run: |
+          sudo apt-get update && sudo apt-get --yes --force-yes install jq
+          PKG_NAME="$(cat package.json | jq -r .name)"
+          cp ${{ env.JAR }} ./npm/aqua-cli.jar
 
-      # - run: npm version ${{ env.VERSION }}
-      #   working-directory: ./npm
+      - run: npm version ${{ env.VERSION }}
+        working-directory: ./npm
 
-      # - run: npm publish --access public
-      #   working-directory: ./npm
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public
+        working-directory: ./npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: determine if release should be drafted
+      - name: Determine if release should be drafted
         run: |
           set -x
-          if [ "${{ github.event.inputs.release }}" = "true" ]; then
+          if [ "${{ github.event.inputs.release }}" = "public" ]; then
             echo "DRAFT=false" >> $GITHUB_ENV
           else
             echo "DRAFT=true" >> $GITHUB_ENV
@@ -101,9 +100,7 @@ jobs:
           automatic_release_tag: "${{ env.BASE_VERSION }}"
           title: "Aqua Compiler ${{ env.VERSION }}"
           files: |
-            
-          body: |
-            [${{ env.VERSION }} @ NPM registry](https://www.npmjs.com/package/${{ env.PKG_NAME }}/v/${{ env.VERSION }})
+            ${{ env.JAR }}
           draft: ${{ env.DRAFT }}
           prerelease: false
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
       - uses: olafurpg/setup-scala@v10
 
       ### Update & build
-      - name: Assembly
-        run: sbt cli/assembly
-        env:
-          BUILD_NUMBER: ${{ github.run_number }}
+      # - name: Assembly
+      #   run: sbt cli/assembly
+      #   env:
+      #     BUILD_NUMBER: ${{ github.run_number }}
 
       ### Create release
       - name: Get project version
@@ -101,7 +101,7 @@ jobs:
           automatic_release_tag: "${{ env.BASE_VERSION }}"
           title: "Aqua Compiler ${{ env.VERSION }}"
           files: |
-            ${{ env.JAR }}
+            
           body: |
             [${{ env.VERSION }} @ NPM registry](https://www.npmjs.com/package/${{ env.PKG_NAME }}/v/${{ env.VERSION }})
           draft: ${{ env.DRAFT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
         run: |
           set -x
           if [ "${{ github.event.inputs.release }}" = "true" ]; then
-            echo "export DRAFT='false'" >> $GITHUB_ENV
+            echo "DRAFT='false'" >> $GITHUB_ENV
           else
-            echo "export DRAFT='true'" >> $GITHUB_ENV
+            echo "DRAFT='true'" >> $GITHUB_ENV
           fi
 
       ### create release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,11 @@ jobs:
         env:
           BUILD_NUMBER: ${{ github.run_number }}
 
-      - name: Check .jar exists
-        run: |
-          JAR="cli/target/scala-2.13/aqua-cli-${{ env.VERSION }}.jar"
-          stat "$JAR"
-          echo "JAR=$JAR" >> $GITHUB_ENV
+      # - name: Check .jar exists
+      #   run: |
+      #     JAR="cli/target/scala-2.13/aqua-cli-${{ env.VERSION }}.jar"
+      #     stat "$JAR"
+      #     echo "JAR=$JAR" >> $GITHUB_ENV
 
       ### Publish to NPM registry
       # - uses: actions/setup-node@v1


### PR DESCRIPTION
You can now create releases manually. It will trigger npm publishing and then create a public github release. You can specify any branch including `main`.

![image](https://user-images.githubusercontent.com/1949356/120015459-0743c100-bfec-11eb-978d-ae3026d42e9e.png)
