### PR TITLE
Added bang op to get array items by index

### DIFF
--- a/aqua-src/error.aqua
+++ b/aqua-src/error.aqua
@@ -13,7 +13,7 @@ service Test("test"):
     getUserList: -> []User
     doSomething: -> bool
 
-func betterMessage(relay: string):
+func betterMessage(relay: string, arr: []string) -> string:
     on relay:
         Peer.is_connected("something")
         par isOnline <- Peer.is_connected(relay)
@@ -25,3 +25,5 @@ func betterMessage(relay: string):
         Test.doSomething()
     else:
       Peer.is_connected("else")
+
+    <- arr!2

--- a/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
@@ -21,6 +21,8 @@ object AirGen {
       s"[@${lambdaToString(tail)}]"
     case IntoFieldModel(field) :: tail =>
       s".$field${lambdaToString(tail)}"
+    case IntoIndexModel(idx) :: tail =>
+      s".[$idx]${lambdaToString(tail)}"
   }
 
   def valueToData(vm: ValueModel): DataView = vm match {

--- a/model/src/main/scala/aqua/model/ValueModel.scala
+++ b/model/src/main/scala/aqua/model/ValueModel.scala
@@ -24,6 +24,7 @@ object LiteralModel {
 sealed trait LambdaModel
 case object IntoArrayModel extends LambdaModel
 case class IntoFieldModel(field: String) extends LambdaModel
+case class IntoIndexModel(idx: Int) extends LambdaModel
 
 case class VarModel(name: String, `type`: Type, lambda: Chain[LambdaModel] = Chain.empty)
     extends ValueModel {

--- a/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
@@ -4,7 +4,7 @@ import aqua.parser.lexer.Token._
 import aqua.parser.lift.LiftParser
 import aqua.parser.lift.LiftParser._
 import cats.data.NonEmptyList
-import cats.parse.{Parser => P}
+import cats.parse.{Numbers, Parser => P, Parser0 => P0}
 import cats.syntax.comonad._
 import cats.syntax.functor._
 import cats.{Comonad, Functor}
@@ -17,6 +17,12 @@ case class IntoField[F[_]: Comonad](name: F[String]) extends LambdaOp[F] {
   def value: String = name.extract
 }
 
+case class IntoIndex[F[_]: Comonad](idx: F[Int]) extends LambdaOp[F] {
+  override def as[T](v: T): F[T] = idx.as(v)
+
+  def value: Int = idx.extract
+}
+
 case class IntoArray[F[_]: Functor](override val unit: F[Unit]) extends LambdaOp[F] {
   override def as[T](v: T): F[T] = unit.as(v)
 }
@@ -25,10 +31,16 @@ object LambdaOp {
 
   private def parseField[F[_]: LiftParser: Comonad]: P[LambdaOp[F]] =
     (`.` *> `name`).lift.map(IntoField(_))
+
   private def parseArr[F[_]: LiftParser: Comonad]: P[LambdaOp[F]] = `*`.lift.map(IntoArray(_))
 
+  private val intP0: P0[Int] = Numbers.nonNegativeIntString.map(_.toInt).?.map(_.getOrElse(0))
+
+  private def parseIdx[F[_]: LiftParser: Comonad]: P[LambdaOp[F]] =
+    ((`!`: P[Unit]) *> intP0).lift.map(IntoIndex(_))
+
   private def parseOp[F[_]: LiftParser: Comonad]: P[LambdaOp[F]] =
-    P.oneOf(parseField.backtrack :: parseArr :: Nil)
+    P.oneOf(parseField.backtrack :: parseArr :: parseIdx :: Nil)
 
   def ops[F[_]: LiftParser: Comonad]: P[NonEmptyList[LambdaOp[F]]] =
     parseOp.rep

--- a/parser/src/main/scala/aqua/parser/lexer/Token.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/Token.scala
@@ -58,6 +58,7 @@ object Token {
   val `.` : P[Unit] = P.char('.')
   val `"` : P[Unit] = P.char('"')
   val `*` : P[Unit] = P.char('*')
+  val `!` : P[Unit] = P.char('!')
   val `[]` : P[Unit] = P.string("[]")
   val `(` : P[Unit] = P.char('(').surroundedBy(` `.?)
   val `)` : P[Unit] = P.char(')').surroundedBy(` `.?)

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -80,6 +80,7 @@ object ValuesAlgebra {
       case Nil => Chain.empty
       case (_: IntoArray[F]) :: tail => opsToModel(tail).prepend(IntoArrayModel)
       case (f: IntoField[F]) :: tail => opsToModel(tail).prepend(IntoFieldModel(f.value))
+      case (i: IntoIndex[F]) :: tail => opsToModel(tail).prepend(IntoIndexModel(i.value))
     }
 
   def valueToModel[F[_]](v: Value[F], t: Type): ValueModel =


### PR DESCRIPTION
Adds `!` operator to get the first item of an array or stream, or to force Option type (see #108).

On arrays and streams, can be followed by an index, e.g.:

```python

arr: []Item

-- First item
arr!

-- 9th item
arr!9

-- Get item's field
arr!.field

```