### PR TITLE
108 option type

### DIFF
--- a/aqua-src/error.aqua
+++ b/aqua-src/error.aqua
@@ -28,6 +28,8 @@ func betterMessage(relay: string, arr: []string, opt: ?string, str: *string) -> 
 
     stream: *string
 
+    localOpt: ?string
+
     if isOnline:
       try:
         Test.doSomething()
@@ -36,6 +38,6 @@ func betterMessage(relay: string, arr: []string, opt: ?string, str: *string) -> 
 
     x <- include(arr)
     y <- include(opt)
-    z <- include(str)
+    localOpt <- include(str)
 
     <- opt

--- a/aqua-src/error.aqua
+++ b/aqua-src/error.aqua
@@ -19,7 +19,7 @@ func include(opt: ?string) -> string:
        Peer.is_connected(i)
     <- opt!
 
-func betterMessage(relay: string, arr: []string, opt: ?string, str: *string) -> string:
+func betterMessage(relay: string, arr: []string, opt: ?string, str: *string) -> ?string:
     on relay:
         Peer.is_connected("something")
         par isOnline <- Peer.is_connected(relay)
@@ -38,4 +38,4 @@ func betterMessage(relay: string, arr: []string, opt: ?string, str: *string) -> 
     y <- include(opt)
     z <- include(str)
 
-    <- opt!
+    <- opt

--- a/aqua-src/error.aqua
+++ b/aqua-src/error.aqua
@@ -13,7 +13,13 @@ service Test("test"):
     getUserList: -> []User
     doSomething: -> bool
 
-func betterMessage(relay: string, arr: []string) -> string:
+func include(opt: ?string) -> string:
+    Peer.is_connected(opt!)
+    for i <- opt:
+       Peer.is_connected(i)
+    <- opt!
+
+func betterMessage(relay: string, arr: []string, opt: ?string, str: *string) -> string:
     on relay:
         Peer.is_connected("something")
         par isOnline <- Peer.is_connected(relay)
@@ -28,4 +34,8 @@ func betterMessage(relay: string, arr: []string) -> string:
     else:
       Peer.is_connected(stream!)
 
-    <- stream!2
+    x <- include(arr)
+    y <- include(opt)
+    z <- include(str)
+
+    <- opt!

--- a/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
@@ -3,7 +3,7 @@ package aqua.backend.air
 import aqua.model._
 import aqua.model.func.Call
 import aqua.model.func.body._
-import aqua.types.StreamType
+import aqua.types.{OptionType, StreamType}
 import cats.Eval
 import cats.data.Chain
 import cats.free.Cofree
@@ -30,6 +30,7 @@ object AirGen {
     case VarModel(name, t, lambda) =>
       val n = t match {
         case _: StreamType => "$" + name
+        case _: OptionType => "$" + name
         case _ => name
       }
       if (lambda.isEmpty) DataView.Variable(n)

--- a/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
+++ b/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
@@ -18,12 +18,19 @@ case class TypescriptFunc(func: FuncCallable) {
 
     val tsAir = FuncAirGen(func).generateClientAir(conf)
 
-    val returnCallback = func.ret.as {
-      s"""h.onEvent('${conf.callbackService}', '${conf.respFuncName}', (args) => {
-         |  const [res] = args;
-         |  resolve(res);
-         |});
-         |""".stripMargin
+    val returnCallback = func.ret.map(_._2).map {
+      case OptionType(_) =>
+        s"""h.onEvent('${conf.callbackService}', '${conf.respFuncName}', (args) => {
+           |  const [res] = args;
+           |  resolve(res.length === 0 ? null : res[0]);
+           |});
+           |""".stripMargin
+      case _ =>
+        s"""h.onEvent('${conf.callbackService}', '${conf.respFuncName}', (args) => {
+           |  const [res] = args;
+           |  resolve(res);
+           |});
+           |""".stripMargin
 
     }
 

--- a/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
+++ b/backend/ts/src/main/scala/aqua/backend/ts/TypescriptFunc.scala
@@ -28,6 +28,8 @@ case class TypescriptFunc(func: FuncCallable) {
     }
 
     val setCallbacks = func.args.args.map {
+      case ArgDef.Data(argName, OptionType(_)) =>
+        s"""h.on('${conf.getDataService}', '$argName', () => {return $argName === null ? [] : [$argName];});"""
       case ArgDef.Data(argName, _) =>
         s"""h.on('${conf.getDataService}', '$argName', () => {return $argName;});"""
       case ArgDef.Arrow(argName, at) =>
@@ -88,6 +90,7 @@ case class TypescriptFunc(func: FuncCallable) {
 object TypescriptFunc {
 
   def typeToTs(t: Type): String = t match {
+    case OptionType(t) => typeToTs(t) + " | null"
     case ArrayType(t) => typeToTs(t) + "[]"
     case StreamType(t) => typeToTs(t) + "[]"
     case pt: ProductType =>

--- a/build.sbt
+++ b/build.sbt
@@ -1,32 +1,32 @@
 val dottyVersion = "2.13.5"
 
-//val dottyVersion = "3.0.0-RC3"
+//val dottyVersion = "3.0.0"
 
 scalaVersion := dottyVersion
 
 val baseAquaVersion = settingKey[String]("base aqua version")
 
-val catsV = "2.6.0"
-val catsParseV = "0.3.3"
+val catsV = "2.6.1"
+val catsParseV = "0.3.4"
 val monocleV = "3.0.0-M5"
-val scalaTestV = "3.2.7" // TODO update version for scala 3-RC3
-val fs2V = "3.0.2"
-val catsEffectV = "3.1.0"
+val scalaTestV = "3.2.9"
+val fs2V = "3.0.4"
+val catsEffectV = "3.1.1"
 val airframeLogV = "21.5.4"
 val log4catsV = "2.1.1"
-val enumeratumV = "1.6.1"
-val slf4jV = "1.7.25"
+val enumeratumV = "1.6.1" // Scala3 issue: https://github.com/lloydmeta/enumeratum/issues/300
+val slf4jV = "1.7.30"
 val declineV = "2.0.0-RC1" // Scala3 issue: https://github.com/bkirwi/decline/issues/260
 val declineEnumV = "1.3.0"
 
 name := "aqua-hll"
 
 val commons = Seq(
-  baseAquaVersion := "0.1.3",
+  baseAquaVersion := "0.1.4",
   version         := baseAquaVersion.value + "-" + sys.env.getOrElse("BUILD_NUMBER", "SNAPSHOT"),
   scalaVersion    := dottyVersion,
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "log4cats-core" % "2.1.1",
+    "org.typelevel" %% "log4cats-core" % log4catsV,
     "org.scalatest" %% "scalatest"     % scalaTestV % Test
   ),
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full)

--- a/model/src/main/scala/aqua/model/func/body/FuncOps.scala
+++ b/model/src/main/scala/aqua/model/func/body/FuncOps.scala
@@ -10,6 +10,11 @@ object FuncOps {
   def noop(peerId: ValueModel): FuncOp =
     FuncOp.leaf(CallServiceTag(LiteralModel.quote("op"), "identity", Call(Nil, None), Some(peerId)))
 
+  def identity(what: ValueModel, to: Call.Export): FuncOp =
+    FuncOp.leaf(
+      CallServiceTag(LiteralModel.quote("op"), "identity", Call(what :: Nil, Some(to)), None)
+    )
+
   def callService(srvId: ValueModel, funcName: String, call: Call): FuncOp =
     FuncOp.leaf(
       CallServiceTag(
@@ -48,4 +53,13 @@ object FuncOps {
 
   def xor(left: FuncOp, right: FuncOp): FuncOp =
     FuncOp.node(XorTag, Chain(left, right))
+
+  def fold(item: String, iter: ValueModel, op: FuncOp): FuncOp =
+    FuncOp.wrap(
+      ForTag(item, iter),
+      op
+    )
+
+  def next(item: String): FuncOp =
+    FuncOp.leaf(NextTag(item))
 }

--- a/model/src/main/scala/aqua/model/transform/ArgsProvider.scala
+++ b/model/src/main/scala/aqua/model/transform/ArgsProvider.scala
@@ -1,9 +1,10 @@
 package aqua.model.transform
 
-import aqua.model.ValueModel
+import aqua.model.{ValueModel, VarModel}
 import aqua.model.func.Call
 import aqua.model.func.body.{FuncOp, FuncOps}
-import aqua.types.DataType
+import aqua.types.{ArrayType, DataType, OptionType, StreamType, Type}
+import cats.data.Chain
 
 trait ArgsProvider {
   def transform(op: FuncOp): FuncOp
@@ -12,12 +13,39 @@ trait ArgsProvider {
 case class ArgsFromService(dataServiceId: ValueModel, names: List[(String, DataType)])
     extends ArgsProvider {
 
-  def getDataOp(name: String, t: DataType): FuncOp =
-    FuncOps.callService(
-      dataServiceId,
-      name,
-      Call(Nil, Some(Call.Export(name, t)))
+  private def getDataElOp(name: String, t: DataType, el: Type): FuncOp = {
+    val iter = s"$name-iter"
+    val item = s"$name-item"
+    FuncOps.seq(
+      FuncOps.callService(
+        dataServiceId,
+        name,
+        Call(Nil, Some(Call.Export(iter, t)))
+      ),
+      FuncOps.fold(
+        item,
+        VarModel(iter, ArrayType(el), Chain.empty),
+        FuncOps.seq(
+          FuncOps.identity(VarModel(item, el), Call.Export(name, t)),
+          FuncOps.next(item)
+        )
+      )
     )
+  }
+
+  def getDataOp(name: String, t: DataType): FuncOp =
+    t match {
+      case StreamType(el) =>
+        getDataElOp(name, t, el)
+      case OptionType(el) =>
+        getDataElOp(name, StreamType(el), el)
+      case _ =>
+        FuncOps.callService(
+          dataServiceId,
+          name,
+          Call(Nil, Some(Call.Export(name, t)))
+        )
+    }
 
   def transform(op: FuncOp): FuncOp =
     FuncOps.seq(

--- a/semantics/src/main/scala/aqua/semantics/expr/DeclareStreamSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/DeclareStreamSem.scala
@@ -5,7 +5,7 @@ import aqua.parser.expr.DeclareStreamExpr
 import aqua.semantics.Prog
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
-import aqua.types.{ArrayType, StreamType}
+import aqua.types.{ArrayType, OptionType, StreamType}
 import cats.free.Free
 
 class DeclareStreamSem[F[_]](val expr: DeclareStreamExpr[F]) {
@@ -19,6 +19,8 @@ class DeclareStreamSem[F[_]](val expr: DeclareStreamExpr[F]) {
         .flatMap {
           case Some(t: StreamType) =>
             N.define(expr.name, t)
+          case Some(t: OptionType) =>
+            N.define(expr.name, StreamType(t.element))
           case Some(at @ ArrayType(t)) =>
             T.ensureTypeMatches(expr.`type`, StreamType(t), at)
           case Some(t) =>

--- a/semantics/src/main/scala/aqua/semantics/expr/ForSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ForSem.scala
@@ -7,7 +7,7 @@ import aqua.semantics.Prog
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
-import aqua.types.{ArrayType, StreamType, Type}
+import aqua.types.{ArrayType, OptionType, StreamType, Type}
 import cats.data.Chain
 import cats.free.Free
 import cats.syntax.flatMap._
@@ -24,9 +24,11 @@ class ForSem[F[_]](val expr: ForExpr[F]) extends AnyVal {
       N.beginScope(expr.item) >> V.valueToModel(expr.iterable).flatMap[Option[ValueModel]] {
         case Some(vm) =>
           vm.lastType match {
-            case at @ ArrayType(t) =>
+            case ArrayType(t) =>
               N.define(expr.item, t).as(Option(vm))
-            case st @ StreamType(t) =>
+            case StreamType(t) =>
+              N.define(expr.item, t).as(Option(vm))
+            case OptionType(t) =>
               N.define(expr.item, t).as(Option(vm))
             case dt =>
               T.ensureTypeMatches(expr.iterable, ArrayType(dt), dt).as(Option.empty[ValueModel])

--- a/semantics/src/main/scala/aqua/semantics/expr/ForSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ForSem.scala
@@ -7,7 +7,7 @@ import aqua.semantics.Prog
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
-import aqua.types.{ArrayType, OptionType, StreamType, Type}
+import aqua.types.{ArrayType, BoxType}
 import cats.data.Chain
 import cats.free.Free
 import cats.syntax.flatMap._
@@ -24,12 +24,8 @@ class ForSem[F[_]](val expr: ForExpr[F]) extends AnyVal {
       N.beginScope(expr.item) >> V.valueToModel(expr.iterable).flatMap[Option[ValueModel]] {
         case Some(vm) =>
           vm.lastType match {
-            case ArrayType(t) =>
-              N.define(expr.item, t).as(Option(vm))
-            case StreamType(t) =>
-              N.define(expr.item, t).as(Option(vm))
-            case OptionType(t) =>
-              N.define(expr.item, t).as(Option(vm))
+            case t: BoxType =>
+              N.define(expr.item, t.element).as(Option(vm))
             case dt =>
               T.ensureTypeMatches(expr.iterable, ArrayType(dt), dt).as(Option.empty[ValueModel])
           }

--- a/types/src/main/scala/aqua/types/Type.scala
+++ b/types/src/main/scala/aqua/types/Type.scala
@@ -83,11 +83,15 @@ object LiteralType {
   val string = LiteralType(Set(ScalarType.string), "string")
 }
 
-case class ArrayType(element: Type) extends DataType {
+sealed trait BoxType extends DataType {
+  def element: Type
+}
+
+case class ArrayType(element: Type) extends BoxType {
   override def toString: String = "[]" + element
 }
 
-case class OptionType(element: Type) extends DataType {
+case class OptionType(element: Type) extends BoxType {
   override def toString: String = "?" + element
 }
 
@@ -108,7 +112,7 @@ case class ArrowType(args: List[Type], res: Option[Type]) extends Type {
     args.map(_.toString).mkString(", ") + " -> " + res.map(_.toString).getOrElse("()")
 }
 
-case class StreamType(element: Type) extends DataType
+case class StreamType(element: Type) extends BoxType
 
 object Type {
   import Double.NaN

--- a/types/src/main/scala/aqua/types/Type.scala
+++ b/types/src/main/scala/aqua/types/Type.scala
@@ -87,6 +87,10 @@ case class ArrayType(element: Type) extends DataType {
   override def toString: String = "[]" + element
 }
 
+case class OptionType(element: Type) extends DataType {
+  override def toString: String = "?" + element
+}
+
 case class ProductType(name: String, fields: NonEmptyMap[String, Type]) extends DataType {
 
   override def toString: String =
@@ -149,6 +153,9 @@ object Type {
         case (x: ScalarType, LiteralType(ys, _)) if ys(x) => 1.0
         case (x: ArrayType, y: ArrayType) => cmp(x.element, y.element)
         case (x: ArrayType, y: StreamType) => cmp(x.element, y.element)
+        case (x: ArrayType, y: OptionType) => cmp(x.element, y.element)
+        case (x: OptionType, y: StreamType) => cmp(x.element, y.element)
+        case (x: OptionType, y: ArrayType) => cmp(x.element, y.element)
         case (x: StreamType, y: StreamType) => cmp(x.element, y.element)
         case (ProductType(_, xFields), ProductType(_, yFields)) =>
           cmpProd(xFields, yFields)

--- a/types/src/test/scala/aqua/types/TypeSpec.scala
+++ b/types/src/test/scala/aqua/types/TypeSpec.scala
@@ -12,6 +12,8 @@ class TypeSpec extends AnyFlatSpec with Matchers {
   import aqua.types.ScalarType._
 
   def `[]`(t: DataType): DataType = ArrayType(t)
+  def `?`(t: DataType): DataType = OptionType(t)
+  def `*`(t: DataType): DataType = StreamType(t)
 
   def accepts(recv: Type, incoming: Type) =
     recv >= incoming
@@ -101,6 +103,15 @@ class TypeSpec extends AnyFlatSpec with Matchers {
     accepts(array, stream) should be(true)
     accepts(stream, array) should be(false)
     accepts(stream, stream) should be(true)
+  }
+
+  "streams" should "be accepted as an option, but not vice versa" in {
+    val stream: Type = StreamType(bool)
+    val opt: Type = OptionType(bool)
+
+    accepts(opt, stream) should be(true)
+    accepts(stream, opt) should be(false)
+    accepts(opt, opt) should be(true)
   }
 
 }


### PR DESCRIPTION
Fixes #108.

With this PR you can use option types in arguments, return values, and complex types. The syntax is the following:

```python

func usingOptions(optString: ?string) -> ?string:
   -- Force the element, will throw if the value is empty
   Peer.is_connected(optString!)
   <- optString
```

Returning values from different branches, as expressed in #108, can be achieved using streams and bang operator:

```python

func returnFromBranches() -> bool:
   ret: *bool
   -- Can also be ret: ?bool
   if true == false:
       ret <- Peer.is_connected()
   else:
       ret <- Some.falsy()
   <- ret!
```

A stream can be provided in place of option value:

```python

func returnFromBranches() -> ?bool:
   ret: *bool
   try:
       ret <- Peer.is_connected()
   <- ret
```

Providing an optional value with a checked one-shot resolution in the scope will be done as a separate feature.

Typescript handles optional values as `| null`.