### PR TITLE
170 pass constants as arguments

### DIFF
--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -53,6 +53,6 @@ jobs:
           cd aqua-playground
           npm i
           cd ..
-          sbt "cli/run -i aqua-playground/aqua/examples -o aqua-playground/src/compiled/examples -m aqua-playground/node_modules"
+          sbt "cli/run -i aqua-playground/aqua/examples -o aqua-playground/src/compiled/examples -m aqua-playground/node_modules -c \"uniqueConst = 1\" -c \"anotherConst = \\\"ab\\\"\""
           cd aqua-playground
           npm run examples

--- a/cli/src/main/scala/aqua/AppOps.scala
+++ b/cli/src/main/scala/aqua/AppOps.scala
@@ -97,7 +97,7 @@ object AppOps {
 
   def constantOpts[F[_]: LiftParser: Comonad]: Opts[List[Constant]] =
     Opts
-      .options[String]("constant", "Constant that will be used in an aqua code", "c")
+      .options[String]("const", "Constant that will be used in an aqua code", "c")
       .mapValidated { strs =>
         val parsed = strs.map(s => ConstantExpr.onlyLiteral.parseAll(s))
         println(parsed)

--- a/cli/src/main/scala/aqua/AppOps.scala
+++ b/cli/src/main/scala/aqua/AppOps.scala
@@ -1,12 +1,16 @@
 package aqua
 
-import cats.Functor
+import aqua.model.LiteralModel
+import aqua.model.transform.Constant
+import aqua.parser.expr.ConstantExpr
+import aqua.parser.lift.LiftParser
 import cats.data.Validated.{Invalid, Valid}
-import cats.data.{Validated, ValidatedNel}
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import cats.effect.ExitCode
 import cats.effect.std.Console
 import cats.syntax.functor._
 import cats.syntax.traverse._
+import cats.{Comonad, Functor}
 import com.monovore.decline.Opts.help
 import com.monovore.decline.enumeratum._
 import com.monovore.decline.{Opts, Visibility}
@@ -90,6 +94,28 @@ object AppOps {
         }.map(_.to(LazyList))
       }
       .withDefault(LazyList.empty)
+
+  def constantOpts[F[_]: LiftParser: Comonad]: Opts[List[Constant]] =
+    Opts
+      .options[String]("constant", "Constant that will be used in an aqua code", "c")
+      .mapValidated { strs =>
+        val parsed = strs.map(s => ConstantExpr.onlyLiteral.parseAll(s))
+        println(parsed)
+        val errors = parsed.collect { case Left(er) =>
+          er
+        }
+
+        NonEmptyList
+          .fromList(errors)
+          .fold(
+            Validated.validNel[String, List[Constant]](parsed.collect { case Right(v) =>
+              Constant(v._1.value, LiteralModel(v._2.value, v._2.ts))
+            })
+          ) { errors =>
+            Validated.invalid(errors.map(_.toString))
+          }
+      }
+      .withDefault(List.empty)
 
   val compileToAir: Opts[Boolean] =
     Opts

--- a/model/src/main/scala/aqua/model/transform/BodyConfig.scala
+++ b/model/src/main/scala/aqua/model/transform/BodyConfig.scala
@@ -21,7 +21,6 @@ case class BodyConfig(
   val callbackSrvId: ValueModel = LiteralModel.quote(callbackService)
   val dataSrvId: ValueModel = LiteralModel.quote(getDataService)
 
-  // TODO: add constants to BodyConfig, and register there
   implicit val aquaContextMonoid: Monoid[AquaContext] = {
     val constantsMap = constants.map(c => c.name -> c.value).toMap
     AquaContext

--- a/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
@@ -2,7 +2,7 @@ package aqua.parser.expr
 
 import aqua.parser.Expr
 import aqua.parser.lexer.Token._
-import aqua.parser.lexer.{Name, Value}
+import aqua.parser.lexer.{Literal, Name, Value}
 import aqua.parser.lift.LiftParser
 import cats.Comonad
 import cats.parse.{Parser => P}
@@ -15,11 +15,16 @@ case class ConstantExpr[F[_]](
 
 object ConstantExpr extends Expr.Leaf {
 
-  override def p[F[_]: LiftParser: Comonad]: P[ConstantExpr[F]] = {
+  override def p[F[_]: LiftParser: Comonad]: P[ConstantExpr[F]] =
     ((((`const` *> ` ` *> Name
       .p[F] <* ` `) ~ `?`.?).with1 <* `=` <* ` `) ~ Value.`value`).map {
       case ((name, mark), value) =>
         ConstantExpr(name, value, mark.nonEmpty)
     }
-  }
+
+  def onlyLiteral[F[_]: LiftParser: Comonad]: P[(Name[F], Literal[F])] =
+    ((((Name
+      .p[F] <* ` `) ~ `?`.?).with1 <* `=` <* ` `) ~ Value.literal).map { case ((name, _), value) =>
+      (name, value)
+    }
 }


### PR DESCRIPTION
fixes #170 

Usage:
You can override constants with a question mark or use inexistent constants here:
```
import "@fluencelabs/aqua-lib/builtin.aqua"

service Cast("test"):
    -- create string from u32
    str: u32 -> string

service OpO("op"):
    identity: string -> string

const anotherConst ?= "default-str"

func callConstant() -> []string:
    res: *string
    res <- Cast.str(uniqueConst)
    res <- OpO.identity(anotherConst)
    <- res
```
with:
```
java ...  -c "uniqueConst = 1" -c "anotherConst = \"ab\""
```
The result will be `['1', 'ab']`