### PR TITLE
Use backwards compatible syntax for config.ttl

### DIFF
--- a/backend/ts/src/main/scala/aqua/backend/ts/TypeScriptFunc.scala
+++ b/backend/ts/src/main/scala/aqua/backend/ts/TypeScriptFunc.scala
@@ -91,7 +91,7 @@ case class TypeScriptFunc(func: FuncCallable) {
        |            .handleTimeout(() => {
        |                reject('Request timed out for ${func.funcName}');
        |            })
-       |        if(${configArgName}?.ttl) {
+       |        if(${configArgName} && ${configArgName}.ttl) {
        |            r.withTTL(${configArgName}.ttl)
        |        }
        |        request = r.build();


### PR DESCRIPTION
`config?.ttl` syntax isn't supported on older TypeScript versions

![telegram-cloud-photo-size-2-5447544950276338726-x](https://user-images.githubusercontent.com/1949356/126039855-5b6779b5-df02-4f9f-8032-01700d6797bd.jpg)
