### PR TITLE
Fix incorrect compilation with arguments duplication

### DIFF
--- a/aqua-src/test.aqua
+++ b/aqua-src/test.aqua
@@ -1,11 +1,8 @@
-service OpH("op"):
-  get_str(s: string) -> string
-  get_arr() -> []string
-  identity: ⊤ -> ⊥
+service AquaDHT("aqua-dht"):
+  put_host_value(key: string, value: string, service_id: []string)
 
-func registerKeyPutValue(node_id: string) -> []string:
-  nodes <- OpH.get_arr()
-  for n <- nodes par:
-    on n:
-      OpH.get_str(node_id)
-  <- nodes
+func putHostValue(key: string, value: string, service_id: ?string):
+    AquaDHT.put_host_value(key, value, service_id)
+
+func create_client_util(service_id: string):
+    putHostValue("client-util", service_id, nil)

--- a/model/src/main/scala/aqua/model/func/FuncCallable.scala
+++ b/model/src/main/scala/aqua/model/func/FuncCallable.scala
@@ -1,6 +1,6 @@
 package aqua.model.func
 
-import aqua.model.func.raw.{AssignmentTag, CallArrowTag, CallServiceTag, FuncOp, RawTag}
+import aqua.model.func.raw.{AssignmentTag, CallArrowTag, FuncOp, RawTag}
 import aqua.model.{Model, ValueModel, VarModel}
 import aqua.types.{ArrowType, Type}
 import cats.Eval
@@ -47,15 +47,21 @@ case class FuncCallable(
     // Collect all arguments: what names are used inside the function, what values are received
     val argsFull = args.call(call)
     // DataType arguments
-    val argsToData = argsFull.dataArgs
+    val argsToDataRaw = argsFull.dataArgs
     // Arrow arguments: expected type is Arrow, given by-name
-    val argsToArrows = argsFull.arrowArgs(arrows)
+    val argsToArrowsRaw = argsFull.arrowArgs(arrows)
+
+    // Find all duplicates in arguments
+    val argsShouldRename = findNewNames(forbiddenNames, (argsToDataRaw ++ argsToArrowsRaw).keySet)
+    val argsToData = argsToDataRaw.map { case (k, v) => argsShouldRename.getOrElse(k, k) -> v }
+    val argsToArrows = argsToArrowsRaw.map { case (k, v) => argsShouldRename.getOrElse(k, k) -> v }
 
     // Going to resolve arrows: collect them all. Names should never collide: it's semantically checked
     val allArrows = capturedArrows ++ argsToArrows
 
     // Substitute arguments (referenced by name and optional lambda expressions) with values
-    val treeWithValues = body.resolveValues(argsToData)
+    // Also rename all renamed arguments in the body
+    val treeWithValues = body.rename(argsShouldRename).resolveValues(argsToData)
 
     // Function body on its own defines some values; collect their names
     val treeDefines = treeWithValues.definesVarNames.value -- call.exportTo.map(_.name)

--- a/model/src/main/scala/aqua/model/func/FuncCallable.scala
+++ b/model/src/main/scala/aqua/model/func/FuncCallable.scala
@@ -69,8 +69,7 @@ case class FuncCallable(
     // We have some names in scope (forbiddenNames), can't introduce them again; so find new names
     val shouldRename = findNewNames(forbiddenNames, treeDefines)
     // If there was a collision, rename exports and usages with new names
-    val treeRenamed =
-      if (shouldRename.isEmpty) treeWithValues else treeWithValues.rename(shouldRename)
+    val treeRenamed = treeWithValues.rename(shouldRename)
 
     // Result could be derived from arguments, or renamed; take care about that
     val result = ret.map(_._1).map(_.resolveWith(argsToData)).map {


### PR DESCRIPTION
```
service AquaDHT("aqua-dht"):
  put_host_value(key: string, value: string, service_id: []string)

func putHostValue(key: string, value: string, service_id: ?string):
    AquaDHT.put_host_value(key, value, service_id)

func create_client_util(service_id: string):
    putHostValue("client-util", service_id, nil)
```

This code should be compiled with correct arguments
```
(xor
 (seq
  (seq
   (call %init_peer_id% ("getDataSrv" "-relay-") [] -relay-)
   (call %init_peer_id% ("getDataSrv" "service_id") [] service_id)
  )
  (call %init_peer_id% ("aqua-dht" "put_host_value") ["client-util" service_id $nil])
 )
 (call %init_peer_id% ("errorHandlingSrv" "error") [%last_error% 1])
)
```