### PR TITLE
CI: Do not trigger releases on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,5 +91,6 @@ jobs:
           body: ${{ steps.github_release.outputs.changelog }}
           draft: false
           prerelease: false
+          files: ${{ env.JAR }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: "release"
 
 on:
-  push:
-    branches:
-      - "main"
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I've left `on push` by mistake in #220. This PR removes it, so release happens only on a button click in Actions.

P.S. Keep in mind that the current release workflow doesn't play well with releases on the same x.y.z version, i.e. it spams the changelog. AFAIK this is OK since it's not intended to be used this way. 