### PR TITLE
Pass stream arguments to callbacks properly

### DIFF
--- a/aqua-src/ret.aqua
+++ b/aqua-src/ret.aqua
@@ -1,31 +1,7 @@
-module Ret
+module Ret declares *
 
-import Service from "service"
+export someFunc
 
-use "error.aqua"
-export GetStr, multiReturnFunc, Service as S
-
-service GetStr("multiret-test"):
-    retStr: string -> string
-
-service GetNum("multiret-num"):
-    retNum: -> u8
-
-const SOME_NUM = 5
-const SOME_STR = "some-str"
-
-func tupleFunc() -> string, u8:
-    str <- GetStr.retStr(SOME_STR)
-    n <- GetNum.retNum()
-    Err.Peer.is_connected("Connected?")
-    <- str, n
-
-func multiReturnFunc(somethingToReturn: []u8, smthOption: ?string) -> []string, u8, string, []u8, ?string, u8:
-    res: *string
-    res <- GetStr.retStr(SOME_STR)
-    try:
-        res <- GetStr.retStr("random-str")
-    catch e:
-        GetStr.retStr(e.msg)
-    res, tNum <- tupleFunc()
-    <- res, 5, SOME_STR, somethingToReturn, smthOption, tNum
+func someFunc(cb: []string -> ()):
+	ifaces: *string
+	cb(ifaces)

--- a/model/src/main/scala/aqua/model/func/FuncCallable.scala
+++ b/model/src/main/scala/aqua/model/func/FuncCallable.scala
@@ -3,7 +3,7 @@ package aqua.model.func
 import aqua.model.ValueModel.varName
 import aqua.model.func.raw.*
 import aqua.model.{Model, ValueModel, VarModel}
-import aqua.types.{ArrayType, ArrowType, ProductType, StreamType, Type}
+import aqua.types.*
 import cats.Eval
 import cats.data.Chain
 import cats.free.Cofree
@@ -110,6 +110,15 @@ case class FuncCallable(
           (
             noNames,
             resolvedExports + (assignTo -> value.resolveWith(resolvedExports))
+          ) -> Cofree[Chain, RawTag](
+            tag.mapValues(_.resolveWith(resolvedExports)),
+            Eval.now(Chain.empty)
+          )
+
+        case ((noNames, resolvedExports), tag @ DeclareStreamTag(value, name)) =>
+          (
+            noNames,
+            resolvedExports + (name -> value.resolveWith(resolvedExports))
           ) -> Cofree[Chain, RawTag](
             tag.mapValues(_.resolveWith(resolvedExports)),
             Eval.now(Chain.empty)

--- a/model/src/main/scala/aqua/model/func/raw/RawTag.scala
+++ b/model/src/main/scala/aqua/model/func/raw/RawTag.scala
@@ -34,6 +34,8 @@ sealed trait RawTag {
       )
     case AssignmentTag(value, assignTo) =>
       AssignmentTag(f(value), assignTo)
+    case DeclareStreamTag(value, name) =>
+      DeclareStreamTag(f(value), name)
     case AbilityIdTag(value, ability) =>
       AbilityIdTag(f(value), ability)
     case _ => this
@@ -73,6 +75,11 @@ case class CallArrowTag(
   funcName: String,
   call: Call
 ) extends RawTag
+
+case class DeclareStreamTag(
+  value: ValueModel,
+  name: String
+) extends NoExecTag
 
 case class AssignmentTag(
   value: ValueModel,


### PR DESCRIPTION
Right now this code:
```
module Ret declares *

export someFunc

func someFunc(cb: []string -> ()):
	ifaces: *string
	cb(ifaces)
```

Creates air that pass `ifaces` not as stream
```
(call %init_peer_id% ("callbackSrv" "cb") [ifaces])
```
