### PR TITLE
#321 restricted stream scopes

### DIFF
--- a/aqua-src/restrict.aqua
+++ b/aqua-src/restrict.aqua
@@ -1,6 +1,6 @@
 module Restrict
 
-export withLoop, buildOptUsage, checkKeepReturn, checkKeepArg
+export withLoop, buildOptUsage, checkKeepReturn, checkKeepArg, retrieve_records
 
 
 func withLoop(xs: []string):
@@ -51,9 +51,3 @@ func retrieve_records(peer: string) -> [][]string:
     records: *[]string
     append_records(peer, records)
     <- records
-
---    registerTestService({
---        get_records: (key) => {
---            return [key, key];
---        },
---    });

--- a/aqua-src/restrict.aqua
+++ b/aqua-src/restrict.aqua
@@ -16,6 +16,8 @@ func buildOpt() -> ?string:
 func buildOptUsage():
   a <- buildOpt()
   b <- buildOpt()
+  for x <- b:
+    z <- buildOpt()
 
 func keepReturn() -> *string:
   s: *string

--- a/aqua-src/restrict.aqua
+++ b/aqua-src/restrict.aqua
@@ -39,3 +39,21 @@ func checkKeepArg() -> []string, []string:
   y <- keepArg(a)
   a <<- "more"
   <- a, y
+  
+-- failing Aqua code:
+service TestService("test-service"):
+    get_records(key: string) -> []string
+
+func append_records(peer: string, srum: *[]string):
+  srum <- TestService.get_records(peer)
+
+func retrieve_records(peer: string) -> [][]string:
+    records: *[]string
+    append_records(peer, records)
+    <- records
+
+--    registerTestService({
+--        get_records: (key) => {
+--            return [key, key];
+--        },
+--    });

--- a/aqua-src/restrict.aqua
+++ b/aqua-src/restrict.aqua
@@ -1,0 +1,39 @@
+module Restrict
+
+export withLoop, buildOptUsage, checkKeepReturn, checkKeepArg
+
+
+func withLoop(xs: []string):
+  for x <- xs:
+    s: *string
+    s <<- x
+
+func buildOpt() -> ?string:
+  s: *string
+  s <<- "none"
+  <- s
+
+func buildOptUsage():
+  a <- buildOpt()
+  b <- buildOpt()
+
+func keepReturn() -> *string:
+  s: *string
+  s <<- "should be not restricted"
+  <- s
+
+func checkKeepReturn() -> []string:
+  s <- keepReturn()
+  s <<- "and more"
+  <- s
+
+func keepArg(arg: *string) -> []string:
+  arg <<- "push more"
+  <- arg
+
+func checkKeepArg() -> []string, []string:
+  a: *string
+  keepArg(a)
+  y <- keepArg(a)
+  a <<- "more"
+  <- a, y

--- a/backend/air/src/main/scala/aqua/backend/air/Air.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/Air.scala
@@ -10,6 +10,7 @@ object Keyword {
 
   case object Null extends Keyword("null")
 
+  case object New extends Keyword("new")
   case object Next extends Keyword("next")
 
   case object Fold extends Keyword("fold")
@@ -78,6 +79,8 @@ object Air {
 
   case object Null extends Air(Keyword.Null)
 
+  case class New(item: DataView, instruction: Air) extends Air(Keyword.New)
+
   case class Next(label: String) extends Air(Keyword.Next)
 
   case class Fold(iterable: DataView, label: String, instruction: Air) extends Air(Keyword.Fold)
@@ -114,6 +117,7 @@ object Air {
           (air match {
             case Air.Null ⇒ ""
             case Air.Next(label) ⇒ s" $label"
+            case Air.New(item, inst) ⇒ s" ${item.show}\n${showNext(inst)}$space"
             case Air.Fold(iter, label, inst) ⇒ s" ${iter.show} $label\n${showNext(inst)}$space"
             case Air.Match(left, right, inst) ⇒
               s" ${left.show} ${right.show}\n${showNext(inst)}$space"

--- a/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
@@ -85,6 +85,8 @@ object AirGen extends Logging {
 
       case FoldRes(item, iterable) =>
         Eval later ForGen(valueToData(iterable), item, opsToSingle(ops))
+      case RestrictionRes(item, isStream) =>
+        Eval later NewGen(item, isStream, opsToSingle(ops))
       case CallServiceRes(serviceId, funcName, CallRes(args, exportTo), peerId) =>
         Eval.later(
           ServiceCallGen(
@@ -149,6 +151,12 @@ case class MatchMismatchGen(
 
 case class ForGen(iterable: DataView, item: String, body: AirGen) extends AirGen {
   override def generate: Air = Air.Fold(iterable, item, body.generate)
+}
+
+case class NewGen(item: String, isStream: Boolean, body: AirGen) extends AirGen {
+
+  override def generate: Air =
+    Air.New(if (isStream) DataView.Stream("$" + item) else DataView.Variable(item), body.generate)
 }
 
 case class NextGen(item: String) extends AirGen {

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val circeVersion = "0.14.1"
 name := "aqua-hll"
 
 val commons = Seq(
-  baseAquaVersion := "0.4.1",
+  baseAquaVersion := "0.5.0",
   version         := baseAquaVersion.value + "-" + sys.env.getOrElse("BUILD_NUMBER", "SNAPSHOT"),
   scalaVersion    := dottyVersion,
   libraryDependencies ++= Seq(

--- a/cli/.jvm/src/main/scala/aqua/Test.scala
+++ b/cli/.jvm/src/main/scala/aqua/Test.scala
@@ -22,7 +22,7 @@ object Test extends IOApp.Simple {
       start <- IO(System.currentTimeMillis())
       _ <- AquaPathCompiler
         .compileFilesTo[IO](
-          Path("./aqua-src/closure.aqua"),
+          Path("./aqua-src/restrict.aqua"),
           List(Path("./aqua")),
           Option(Path("./target")),
           TypeScriptBackend,

--- a/model/src/main/scala/aqua/model/func/FuncCallable.scala
+++ b/model/src/main/scala/aqua/model/func/FuncCallable.scala
@@ -80,7 +80,10 @@ case class FuncCallable(
     // Function body on its own defines some values; collect their names
     // except stream arguments. They should be already renamed
     val treeDefines =
-      treeWithValues.definesVarNames.value -- streamArgs.keySet -- call.exportTo.filter { exp =>
+      treeWithValues.definesVarNames.value -- streamArgs.keySet -- streamArgs.values.collect {
+        case VarModel(streamNameWasAlreadySubstitutedAbove, _, _) =>
+          streamNameWasAlreadySubstitutedAbove
+      } -- call.exportTo.filter { exp =>
         exp.`type` match {
           case StreamType(_) => false
           case _ => true

--- a/model/src/main/scala/aqua/model/func/raw/FuncOp.scala
+++ b/model/src/main/scala/aqua/model/func/raw/FuncOp.scala
@@ -32,6 +32,8 @@ case class FuncOp(tree: Cofree[Chain, RawTag]) extends Model {
     case (CallServiceTag(_, _, Call(_, exportTo)), acc) if exportTo.nonEmpty =>
       Eval.later(acc.foldLeft(exportTo.map(_.name).toSet)(_ ++ _))
     case (NextTag(exportTo), acc) => Eval.later(acc.foldLeft(Set(exportTo))(_ ++ _))
+    case (RestrictionTag(name, _), acc) =>
+      Eval.later(acc.foldLeft(Set(name))(_ ++ _))
     case (_, acc) => Eval.later(acc.foldLeft(Set.empty[String])(_ ++ _))
   }
 
@@ -42,6 +44,8 @@ case class FuncOp(tree: Cofree[Chain, RawTag]) extends Model {
       Eval.later(acc.foldLeft(exportTo.map(_.name).toSet)(_ ++ _))
     case (PushToStreamTag(_, exportTo), acc) =>
       Eval.later(acc.foldLeft(Set(exportTo.name))(_ ++ _))
+    case (RestrictionTag(name, _), acc) =>
+      Eval.later(acc.foldLeft(Set.empty[String])(_ ++ _) - name)
     case (CanonicalizeTag(_, exportTo), acc) =>
       Eval.later(acc.foldLeft(Set(exportTo.name))(_ ++ _))
     case (_, acc) => Eval.later(acc.foldLeft(Set.empty[String])(_ ++ _))
@@ -55,6 +59,8 @@ case class FuncOp(tree: Cofree[Chain, RawTag]) extends Model {
       Eval.later(acc.foldLeft(call.argVarNames)(_ ++ _))
     case (PushToStreamTag(operand, _), acc) =>
       Eval.later(acc.foldLeft(ValueModel.varName(operand).toSet)(_ ++ _))
+    case (RestrictionTag(name, _), acc) =>
+      Eval.later(acc.foldLeft(Set.empty[String])(_ ++ _) - name)
     case (CanonicalizeTag(operand, _), acc) =>
       Eval.later(acc.foldLeft(ValueModel.varName(operand).toSet)(_ ++ _))
     case (MatchMismatchTag(a, b, _), acc) =>
@@ -86,6 +92,7 @@ case class FuncOp(tree: Cofree[Chain, RawTag]) extends Model {
             case a: AssignmentTag => a.copy(assignTo = vals.getOrElse(a.assignTo, a.assignTo))
             case t: ForTag if vals.contains(t.item) => t.copy(item = vals(t.item))
             case t: NextTag if vals.contains(t.item) => t.copy(item = vals(t.item))
+            case t: RestrictionTag if vals.contains(t.name) => t.copy(name = vals(t.name))
             case t => t
           }
         )

--- a/model/src/main/scala/aqua/model/func/raw/RawTag.scala
+++ b/model/src/main/scala/aqua/model/func/raw/RawTag.scala
@@ -78,6 +78,7 @@ case class OnTag(peerId: ValueModel, via: Chain[ValueModel]) extends SeqGroupTag
     s"(on $peerId${if (via.nonEmpty) " via " + via.toList.mkString(" via ") else ""})"
 }
 case class NextTag(item: String) extends RawTag
+case class RestrictionTag(name: String, isStream: Boolean) extends SeqGroupTag
 
 case class MatchMismatchTag(left: ValueModel, right: ValueModel, shouldMatch: Boolean)
     extends SeqGroupTag

--- a/model/transform/src/main/scala/aqua/model/transform/res/CallRes.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/res/CallRes.scala
@@ -3,4 +3,6 @@ package aqua.model.transform.res
 import aqua.model.ValueModel
 import aqua.model.func.Call
 
-case class CallRes(args: List[ValueModel], exportTo: Option[Call.Export])
+case class CallRes(args: List[ValueModel], exportTo: Option[Call.Export]) {
+  override def toString: String = s"[${args.mkString(" ")}]${exportTo.fold("")(" " + _)}"
+}

--- a/model/transform/src/main/scala/aqua/model/transform/res/MakeRes.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/res/MakeRes.scala
@@ -46,7 +46,8 @@ object MakeRes {
     )
 
   def resolve(
-    currentPeerId: Option[ValueModel]
+    currentPeerId: Option[ValueModel],
+    i: Int
   ): PartialFunction[RawTag, Res] = {
     case SeqTag => leaf(SeqRes)
     case _: OnTag => leaf(SeqRes)
@@ -59,19 +60,19 @@ object MakeRes {
     case PushToStreamTag(operand, exportTo) =>
       operand.`type` match {
         case StreamType(st) =>
-          val tmpName = "push-to-stream"
-          wrap(
-            RestrictionRes(tmpName, isStream = false),
-            seq(
-              canon(
-                currentPeerId
-                  .getOrElse(LiteralModel.initPeerId),
-                operand,
-                Call.Export(tmpName, ArrayType(st))
-              ),
-              leaf(ApRes(VarModel(tmpName, ArrayType(st)), exportTo))
-            )
+          val tmpName = s"push-to-stream-$i"
+          // wrap (
+          //  RestrictionRes(tmpName, isStream = false),
+          seq(
+            canon(
+              currentPeerId
+                .getOrElse(LiteralModel.initPeerId),
+              operand,
+              Call.Export(tmpName, ArrayType(st))
+            ),
+            leaf(ApRes(VarModel(tmpName, ArrayType(st)), exportTo))
           )
+        // )
         case _ =>
           leaf(ApRes(operand, exportTo))
       }

--- a/model/transform/src/main/scala/aqua/model/transform/res/ResolvedOp.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/res/ResolvedOp.scala
@@ -11,13 +11,22 @@ case object SeqRes extends ResolvedOp
 case object ParRes extends ResolvedOp
 case object XorRes extends ResolvedOp
 
-case class NextRes(item: String) extends ResolvedOp
+case class NextRes(item: String) extends ResolvedOp {
+  override def toString: String = s"(next $item)"
+}
 
 case class MatchMismatchRes(left: ValueModel, right: ValueModel, shouldMatch: Boolean)
     extends ResolvedOp {
   override def toString: String = s"(${if (shouldMatch) "match" else "mismatch"} $left $right)"
 }
-case class FoldRes(item: String, iterable: ValueModel) extends ResolvedOp
+
+case class FoldRes(item: String, iterable: ValueModel) extends ResolvedOp {
+  override def toString: String = s"(fold $iterable $item "
+}
+
+case class RestrictionRes(item: String, isStream: Boolean) extends ResolvedOp {
+  override def toString: String = s"(new ${if (isStream) "$" else ""}$item "
+}
 
 case class AbilityIdRes(
   value: ValueModel,

--- a/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
@@ -48,18 +48,13 @@ object Topology extends Logging {
 
   def resolveOnMoves(op: Tree): Eval[Res] = {
     val cursor = RawCursor(NonEmptyList.one(ChainZipper.one(op)))
-    // TODO: remove var
-    var i = 0
-    def nextI = {
-      i = i + 1
-      i
-    }
+
     val resolvedCofree = cursor
       .cata(wrap) { rc =>
         logger.debug(s"<:> $rc")
         val resolved =
           MakeRes
-            .resolve(rc.currentPeerId, nextI)
+            .resolve(rc.currentPeerId)
             .lift
             .apply(rc.tag)
 

--- a/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
@@ -48,13 +48,19 @@ object Topology extends Logging {
 
   def resolveOnMoves(op: Tree): Eval[Res] = {
     val cursor = RawCursor(NonEmptyList.one(ChainZipper.one(op)))
+    // TODO: remove var
+    var i = 0
+    def nextI = {
+      i = i + 1
+      i
+    }
 
     val resolvedCofree = cursor
       .cata(wrap) { rc =>
         logger.debug(s"<:> $rc")
         val resolved =
           MakeRes
-            .resolve(rc.currentPeerId)
+            .resolve(rc.currentPeerId, nextI)
             .lift
             .apply(rc.tag)
 

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
@@ -1,8 +1,9 @@
 package aqua.semantics.expr.func
 
 import aqua.model.func.ArrowModel
-import aqua.model.func.raw.{FuncOp, FuncOps, ReturnTag, SeqTag}
-import aqua.model.{Model, ValueModel}
+import aqua.model.func.Call
+import aqua.model.func.raw.{FuncOp, FuncOps, RestrictionTag, ReturnTag, SeqTag}
+import aqua.model.{Model, ValueModel, VarModel}
 import aqua.parser.expr.FuncExpr
 import aqua.parser.expr.func.ArrowExpr
 import aqua.parser.lexer.{Arg, DataTypeToken}
@@ -11,7 +12,7 @@ import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.abilities.AbilitiesAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
-import aqua.types.{ArrowType, ProductType, Type}
+import aqua.types.{ArrowType, ProductType, StreamType, Type}
 import cats.data.{Chain, NonEmptyList}
 import cats.free.{Cofree, Free}
 import cats.syntax.applicative.*
@@ -37,7 +38,8 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
       )
       .flatMap((arrowType: ArrowType) =>
         // Create local variables
-        expr.arrowTypeExpr.args.flatMap(_._1)
+        expr.arrowTypeExpr.args
+          .flatMap(_._1)
           .zip(
             arrowType.domain.toList
           )
@@ -55,15 +57,60 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
     N: NamesAlgebra[S, Alg],
     A: AbilitiesAlgebra[S, Alg]
   ): Alg[Model] =
-    A.endScope() *> N.endScope() *> T.endArrowScope(expr.arrowTypeExpr).map { retValues =>
-      bodyGen match {
-        case m: FuncOp =>
-          // TODO: wrap with local on...via...
-          ArrowModel(funcArrow, retValues, m)
-        case m =>
-          m
-      }
-    }
+    A.endScope() *> (N.streamsDefinedWithinScope(), T.endArrowScope(expr.arrowTypeExpr)).mapN {
+      (streams, retValues) =>
+        bodyGen match {
+          case m: FuncOp =>
+            // TODO: wrap with local on...via...
+
+            // These streams are returned as streams
+            val retStreams: Map[String, Option[Type]] =
+              (retValues zip funcArrow.codomain.toList).collect {
+                case (VarModel(n, StreamType(_), _), StreamType(_)) => n -> None
+                case (VarModel(n, StreamType(_), _), t) => n -> Some(t)
+              }.toMap
+
+            val builtStreams = retStreams.collect { case (n, Some(t)) =>
+              n -> t
+            }
+            val escapingStreams = retStreams.collect { case (n, None) =>
+              n
+            }
+
+            // Remove stream arguments, and values returned as streams
+            val localStreams = streams -- funcArrow.domain.labelledData.map(_._1) -- escapingStreams
+
+            // Restrict all the local streams
+            val (body, retValuesFix) = localStreams.foldLeft((m, retValues)) { case ((b, rs), n) =>
+              if (
+                rs.exists {
+                  case VarModel(`n`, _, _) => true
+                  case _ => false
+                }
+              )
+                FuncOp.wrap(
+                  RestrictionTag(n, isStream = true),
+                  FuncOps.seq(
+                    b :: rs.collect { case vn @ VarModel(`n`, _, _) =>
+                      FuncOps.canonicalize(
+                        vn,
+                        Call.Export(s"$n-fix", builtStreams.getOrElse(n, vn.lastType))
+                      )
+                    }: _*
+                  )
+                ) -> rs.map {
+                  case vn @ VarModel(`n`, _, _) =>
+                    VarModel(s"$n-fix", builtStreams.getOrElse(n, vn.lastType))
+                  case vm => vm
+                }
+              else FuncOp.wrap(RestrictionTag(n, isStream = true), b) -> rs
+            }
+
+            ArrowModel(funcArrow, retValuesFix, body)
+          case m =>
+            m
+        }
+    } <* N.endScope()
 
   def program[Alg[_]: Monad](implicit
     T: TypesAlgebra[S, Alg],

--- a/semantics/src/main/scala/aqua/semantics/rules/names/NamesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/names/NamesAlgebra.scala
@@ -21,5 +21,7 @@ trait NamesAlgebra[S[_], Alg[_]] {
 
   def beginScope(token: Token[S]): Alg[Unit]
 
+  def streamsDefinedWithinScope(): Alg[Set[String]]
+
   def endScope(): Alg[Unit]
 }

--- a/semantics/src/main/scala/aqua/semantics/rules/names/NamesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/names/NamesInterpreter.scala
@@ -3,7 +3,7 @@ package aqua.semantics.rules.names
 import aqua.parser.lexer.{Name, Token}
 import aqua.semantics.Levenshtein
 import aqua.semantics.rules.{ReportError, StackInterpreter}
-import aqua.types.{ArrowType, Type}
+import aqua.types.{ArrowType, StreamType, Type}
 import cats.data.{OptionT, State}
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
@@ -127,6 +127,13 @@ class NamesInterpreter[S[_], X](implicit lens: Lens[X, NamesState[S]], error: Re
 
   override def beginScope(token: Token[S]): SX[Unit] =
     stackInt.beginScope(NamesState.Frame(token))
+
+  override def streamsDefinedWithinScope(): SX[Set[String]] =
+    stackInt.mapStackHead(State.pure(Set.empty[String])) { frame =>
+      frame -> frame.names.collect { case (n, StreamType(_)) =>
+        n
+      }.toSet
+    }
 
   override def endScope(): SX[Unit] = stackInt.endScope
 

--- a/types/src/main/scala/aqua/types/Type.scala
+++ b/types/src/main/scala/aqua/types/Type.scala
@@ -162,14 +162,21 @@ object LiteralType {
 }
 
 sealed trait BoxType extends DataType {
+  def isStream: Boolean
   def element: Type
 }
 
 case class ArrayType(element: Type) extends BoxType {
+
+  override def isStream: Boolean = false
+
   override def toString: String = "[]" + element
 }
 
 case class OptionType(element: Type) extends BoxType {
+
+  override def isStream: Boolean = false
+
   override def toString: String = "?" + element
 }
 
@@ -200,6 +207,9 @@ case class ArrowType(domain: ProductType, codomain: ProductType) extends Type {
 }
 
 case class StreamType(element: Type) extends BoxType {
+
+  override def isStream: Boolean = true
+
   override def toString: String = s"*$element"
 }
 


### PR DESCRIPTION
Fixes #321

Should be merged & released After the updated AquaVM is delivered to the node, to fluence-js, and Aqua's internal fluence-js dependency is updated accordingly.