### PR TITLE
Add init_peer_id in output

### DIFF
--- a/cli/.js/src/main/scala/aqua/RunCommand.scala
+++ b/cli/.js/src/main/scala/aqua/RunCommand.scala
@@ -52,6 +52,7 @@ object RunCommand extends Logging {
         .start(PeerConfig(multiaddr, timeout))
         .toFuture
       peer = Fluence.getPeer()
+      _ = println("Your peerId: " + peer.getStatus().peerId)
       promise = Promise.apply[Unit]()
       _ = CallJsFunction.registerUnitService(
         peer,


### PR DESCRIPTION
Right now you cannot check what peerId you use on a running script. Add it to output