### PR TITLE
Fix error when no variables in arguments

### DIFF
--- a/cli/.js/src/main/scala/aqua/run/RunWrapper.scala
+++ b/cli/.js/src/main/scala/aqua/run/RunWrapper.scala
@@ -30,7 +30,7 @@ object RunWrapper {
           )
         case (Some(s), _) => Validated.validNec(s :: Nil)
       }
-    }.reduce(_ combine _)
+    }.reduceOption(_ combine _).getOrElse(Validated.validNec(Nil))
   }
 
   // Wrap a functino like this:


### PR DESCRIPTION
This code throws an error on `aqua run`, but it is valid
```
import Srv, Service from "@fluencelabs/aqua-lib/builtin.aqua"
func list() -> []Service:
    on HOST_PEER_ID:
        result <- Srv.list()
    <- result
```
PR fixes it