### PR TITLE
Scalar index access

### DIFF
--- a/aqua-src/nopingback.aqua
+++ b/aqua-src/nopingback.aqua
@@ -1,10 +1,13 @@
 service HelloWorld("hello-srv"):
   hello: string -> string
 
-func sayHello() -> string:
+data Info:
+  external: []string
+
+func sayHello(info: Info) -> string:
     -- execute computation on a Peer in the network
     on "hello-peer":
-        comp <- HelloWorld.hello(%init_peer_id%)
+        comp <- HelloWorld.hello(info.external!)
 
     -- send the result to target browser in the background
     co on "target-peer" via "target-relay":

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val scribeV = "3.6.3"
 name := "aqua-hll"
 
 val commons = Seq(
-  baseAquaVersion := "0.5.2",
+  baseAquaVersion := "0.5.3",
   version         := baseAquaVersion.value + "-" + sys.env.getOrElse("BUILD_NUMBER", "SNAPSHOT"),
   scalaVersion    := dottyVersion,
   libraryDependencies ++= Seq(

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -102,7 +102,7 @@ case class CallArrowTag(
   funcName: String,
   call: Call
 ) extends RawTag {
-  override def usesVarNames: Set[String] = call.argVarNames
+  override def usesVarNames: Set[String] = call.argVarNames + funcName
 
   override def exportsVarNames: Set[String] = call.exportTo.map(_.name).toSet
 
@@ -230,4 +230,13 @@ case class FlattenTag(operand: ValueRaw, assignTo: String) extends RawTag {
     copy(assignTo = map.getOrElse(assignTo, assignTo))
 
   override def toString: String = s"(ap $operand $assignTo)"
+}
+
+case class JoinTag(operands: NonEmptyList[ValueRaw]) extends RawTag {
+  override def usesVarNames: Set[String] = operands.toList.flatMap(_.usesVarNames).toSet
+
+  override def mapValues(f: ValueRaw => ValueRaw): RawTag =
+    JoinTag(operands.map(_.map(f)))
+
+  override def toString: String = s"(join ${operands.toList.mkString(" ")})"
 }

--- a/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
@@ -16,7 +16,7 @@ sealed trait ValueRaw {
   def lastType: Type = `type`
 
   def renameVars(map: Map[String, String]): ValueRaw = this
-  
+
   def map(f: ValueRaw => ValueRaw): ValueRaw
 
 }
@@ -55,7 +55,7 @@ case class VarRaw(name: String, `type`: Type, lambda: Chain[LambdaRaw] = Chain.e
     lambda.toList.map(_.usesVarNames).foldLeft(Set(name))(_ ++ _)
 
   override val lastType: Type = lambda.lastOption.map(_.`type`).getOrElse(`type`)
-  
+
   override def map(f: ValueRaw => ValueRaw): ValueRaw =
     f(copy(lambda = lambda.map(_.map(f))))
 
@@ -128,6 +128,7 @@ object LiteralRaw {
   def quote(value: String): LiteralRaw = LiteralRaw("\"" + value + "\"", LiteralType.string)
 
   def number(value: Int): LiteralRaw = LiteralRaw(value.toString, LiteralType.number)
+  val Zero: LiteralRaw = LiteralRaw("0", LiteralType.number)
 
   val True: LiteralRaw = LiteralRaw("true", LiteralType.bool)
   val False: LiteralRaw = LiteralRaw("false", LiteralType.bool)

--- a/model/src/main/scala/aqua/model/inline/Sugar.scala
+++ b/model/src/main/scala/aqua/model/inline/Sugar.scala
@@ -2,7 +2,7 @@ package aqua.model.inline
 
 import aqua.model.inline.state.Counter
 import aqua.model.{IntoFieldModel, IntoIndexModel, LambdaModel, LiteralModel, ValueModel, VarModel}
-import aqua.raw.ops.{Call, FlattenTag, FuncOp, ParTag, SeqTag}
+import aqua.raw.ops.*
 import aqua.raw.value.{IntoFieldRaw, IntoIndexRaw, LambdaRaw, LiteralRaw, ValueRaw, VarRaw}
 import cats.data.{Chain, State}
 import cats.syntax.traverse.*
@@ -10,6 +10,7 @@ import cats.instances.list.*
 
 object Sugar {
 
+  // Todo: use state monad instead of counter
   private def unfold(raw: ValueRaw, i: Int): (ValueModel, Map[String, ValueRaw]) = raw match {
     case VarRaw(name, t, lambda) if lambda.isEmpty =>
       VarModel(name, t, Chain.empty) -> Map.empty
@@ -25,9 +26,10 @@ object Sugar {
       VarModel(name, t, lambdaModel) -> map
   }
 
+  // Todo: use state monad instead of counter
   private def unfoldLambda(l: LambdaRaw, i: Int): (LambdaModel, Map[String, ValueRaw]) = l match {
     case IntoFieldRaw(field, t) => IntoFieldModel(field, t) -> Map.empty
-    case IntoIndexRaw(vm @ VarRaw(name, _, l), t) if l.nonEmpty =>
+    case IntoIndexRaw(vm@VarRaw(name, _, l), t) if l.nonEmpty =>
       val ni = name + "-" + i
       IntoIndexModel(ni, t) -> Map(ni -> vm)
     case IntoIndexRaw(VarRaw(name, _, _), t) =>
@@ -36,6 +38,15 @@ object Sugar {
     case IntoIndexRaw(LiteralRaw(value, _), t) =>
       IntoIndexModel(value, t) -> Map.empty
   }
+
+  private def parDesugarPrefix(ops: List[FuncOp]): Option[FuncOp] = ops match {
+    case Nil => None
+    case x :: Nil => Option(x)
+    case _ => Option(FuncOp.node(ParTag, Chain.fromSeq(ops)))
+  }
+
+  private def parDesugarPrefixOpt(ops: Option[FuncOp]*): Option[FuncOp] =
+    parDesugarPrefix(ops.toList.flatten)
 
   def desugarize[S: Counter](value: ValueRaw): State[S, (ValueRaw, Option[FuncOp])] =
     for {
@@ -52,32 +63,69 @@ object Sugar {
             FuncOp.leaf(FlattenTag(v, name))
         }
       }
-
-      // Take values from a chain
-      // for each, recursiveRaw
-      // group all into par
-      // for each, recursiveRaw
-      // if anything returned, put it into seq before this
-    } yield (
-      vm.toRaw,
-      ops match {
-        case Nil => None
-        case x :: Nil => Option(x)
-        case _ => Option(FuncOp.node(ParTag, Chain.fromSeq(ops)))
-      }
-    )
+    } yield vm.toRaw -> parDesugarPrefix(ops)
 
   def desugarize[S: Counter](
-    values: List[ValueRaw]
-  ): State[S, List[(ValueRaw, Option[FuncOp])]] =
+                              values: List[ValueRaw]
+                            ): State[S, List[(ValueRaw, Option[FuncOp])]] =
     values.traverse(desugarize(_))
 
   def desugarize[S: Counter](call: Call): State[S, (Call, Option[FuncOp])] =
     desugarize(call.args).map(list =>
-      call.copy(list.map(_._1)) -> (list.flatMap(_._2) match {
-        case Nil => None
-        case x :: Nil => Option(x)
-        case vs => Option(FuncOp.node(ParTag, Chain.fromSeq(vs)))
-      })
+      call.copy(list.map(_._1)) -> parDesugarPrefix(list.flatMap(_._2))
     )
+
+  // TODO: here we should return smth in between Raw and Res (model?)
+  def desugarize[S: Counter](tag: RawTag): State[S, (RawTag, Option[FuncOp])] =
+    tag match {
+      case OnTag(peerId, via) =>
+        for {
+          peerIdDe <- desugarize(peerId)
+          viaDe <- desugarize(via.toList)
+          (pid, pif) = peerIdDe
+          viaD = Chain.fromSeq(viaDe.map(_._1))
+          viaF = viaDe.flatMap(_._2)
+
+        } yield OnTag(pid, viaD) -> parDesugarPrefix(viaF.prependedAll(pif))
+
+      case MatchMismatchTag(left, right, shouldMatch) =>
+        for {
+          ld <- desugarize(left)
+          rd <- desugarize(right)
+        } yield MatchMismatchTag(ld._1, rd._1, shouldMatch) -> parDesugarPrefixOpt(ld._2, rd._2)
+
+      case ForTag(item, iterable) =>
+        desugarize(iterable).map { case (v, p) =>
+          ForTag(item, v) -> p
+        }
+
+      case CallArrowTag(funcName, call) =>
+        desugarize(call).map {
+          case (c, p) => CallArrowTag(funcName, c) -> p
+        }
+
+      case CallServiceTag(serviceId, funcName, call) =>
+        for {
+          cd <- desugarize(call)
+          sd <- desugarize(serviceId)
+        } yield CallServiceTag(sd._1, funcName, cd._1) -> parDesugarPrefixOpt(sd._2, cd._2)
+
+      case CanonicalizeTag(operand, exportTo) =>
+        desugarize(operand).map { case (v, p) =>
+          CanonicalizeTag(v, exportTo) -> p
+        }
+
+      // TODO: it should not appear as a Tag, only as Res
+      case FlattenTag(operand, assignTo) =>
+        desugarize(operand).map { case (v, p) =>
+          FlattenTag(v, assignTo) -> p
+        }
+
+      case JoinTag(operands) =>
+        operands.traverse(desugarize).map(nel =>
+          JoinTag(nel.map(_._1)) -> parDesugarPrefix(nel.toList.flatMap(_._2))
+        )
+
+      case _ => State.pure(tag -> None)
+    }
 }

--- a/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
@@ -42,8 +42,10 @@ object LambdaOp {
     Numbers.nonNegativeIntString.map(_.toInt).?.map(_.getOrElse(0))
 
   private val parseIdx: P[LambdaOp[Span.S]] =
-    (Value.`value`.between(`[`, `]`) | (exclamation *> Value.`value`)).map(v =>
-      IntoIndex(v, Some(v))
+    P.defer(
+      (Value.`value`.between(`[`, `]`) | (exclamation *> Value.`value`)).map(v =>
+        IntoIndex(v, Some(v))
+      )
     ) |
       exclamation.lift.map(e => IntoIndex(Token.lift[Span.S, Unit](e), None))
 

--- a/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
@@ -43,7 +43,7 @@ object LambdaOp {
 
   private val parseIdx: P[LambdaOp[Span.S]] =
     P.defer(
-      (Value.`value`.between(`[`, `]`) | (exclamation *> Value.`value`)).map(v =>
+      (Value.`value`.between(`[`, `]`).backtrack | (exclamation *> Value.num)).map(v =>
         IntoIndex(v, Some(v))
       )
     ) |

--- a/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/LambdaOp.scala
@@ -43,9 +43,9 @@ object LambdaOp {
 
   private val parseIdx: P[LambdaOp[Span.S]] =
     P.defer(
-      (Value.`value`.between(`[`, `]`).backtrack | (exclamation *> Value.num)).map(v =>
-        IntoIndex(v, Some(v))
-      )
+      (Value.`value`.between(`[`, `]`) | (exclamation *> Value.num))
+        .map(v => IntoIndex(v, Some(v)))
+        .backtrack
     ) |
       exclamation.lift.map(e => IntoIndex(Token.lift[Span.S, Unit](e), None))
 

--- a/parser/src/main/scala/aqua/parser/lexer/Token.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/Token.scala
@@ -2,7 +2,7 @@ package aqua.parser.lexer
 
 import cats.data.NonEmptyList
 import cats.parse.{Accumulator0, Parser as P, Parser0 as P0}
-import cats.{Comonad, Functor, ~>}
+import cats.{~>, Comonad, Functor}
 
 trait Token[F[_]] {
   def as[T](v: T): F[T]
@@ -85,6 +85,8 @@ object Token {
   val `*` : P[Unit] = P.char('*')
   val exclamation: P[Unit] = P.char('!')
   val `[]` : P[Unit] = P.string("[]")
+  val `[` : P[Unit] = P.char('[').surroundedBy(` `.?)
+  val `]` : P[Unit] = P.char(']').surroundedBy(` `.?)
   val `⊤` : P[Unit] = P.char('⊤')
   val `⊥` : P[Unit] = P.char('⊥')
   val `∅` : P[Unit] = P.char('∅')
@@ -102,6 +104,7 @@ object Token {
 
   case class LiftToken[F[_]: Functor, A](point: F[A]) extends Token[F] {
     override def as[T](v: T): F[T] = Functor[F].as(point, v)
+
     override def mapK[K[_]: Comonad](fk: F ~> K): LiftToken[K, A] =
       copy(fk(point))
   }

--- a/semantics/src/main/scala/aqua/semantics/expr/ConstantSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ConstantSem.scala
@@ -20,7 +20,7 @@ class ConstantSem[S[_]](val expr: ConstantExpr[S]) extends AnyVal {
   ): Prog[Alg, Raw] = {
     for {
       defined <- N.constantDefined(expr.name)
-      v <- V.valueToModel(expr.value)
+      v <- V.valueToRaw(expr.value)
       model <- (defined, v.map(v => v -> v.lastType), expr.skipIfAlreadyDefined) match {
         case (Some(definedType), Some((vm, actualType)), true) =>
           T.ensureTypeMatches(expr.value, definedType, actualType).map {

--- a/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
@@ -29,7 +29,7 @@ class ServiceSem[S[_]](val expr: ServiceExpr[S]) extends AnyVal {
             val arrows = nel.map(kv => kv._1.value -> kv._2).toNem
             for {
               defaultId <- expr.id
-                .map(v => V.valueToModel(v))
+                .map(v => V.valueToRaw(v))
                 .getOrElse(None.pure[Alg])
               defineResult <- A.defineService(
                 expr.name,

--- a/semantics/src/main/scala/aqua/semantics/expr/func/AbilityIdSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/AbilityIdSem.scala
@@ -17,7 +17,7 @@ class AbilityIdSem[S[_]](val expr: AbilityIdExpr[S]) extends AnyVal {
     A: AbilitiesAlgebra[S, Alg],
     V: ValuesAlgebra[S, Alg]
   ): Prog[Alg, Raw] =
-    V.ensureIsString(expr.id) >> V.valueToModel(
+    V.ensureIsString(expr.id) >> V.valueToRaw(
       expr.id
     ) >>= {
       case Some(id) =>

--- a/semantics/src/main/scala/aqua/semantics/expr/func/AssignmentSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/AssignmentSem.scala
@@ -17,7 +17,7 @@ class AssignmentSem[S[_]](val expr: AssignmentExpr[S]) extends AnyVal {
     N: NamesAlgebra[S, Alg],
     V: ValuesAlgebra[S, Alg]
   ): Prog[Alg, Raw] =
-    V.valueToModel(expr.value).flatMap {
+    V.valueToRaw(expr.value).flatMap {
       case Some(vm) =>
         N.define(expr.variable, vm.lastType) as (FuncOp
           .leaf(AssignmentTag(vm, expr.variable.value)): Raw)

--- a/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
@@ -47,7 +47,7 @@ class CallArrowSem[S[_]](val expr: CallArrowExpr[S]) extends AnyVal {
         }
       )
       .map(_._1) >>= { (v: List[Type]) =>
-      Traverse[List].traverse(args)(V.valueToModel).map(_.flatten -> v.reverse)
+      Traverse[List].traverse(args)(V.valueToRaw).map(_.flatten -> v.reverse)
     }
 
   private def toModel[Alg[_]: Monad](implicit

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ForSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ForSem.scala
@@ -27,7 +27,7 @@ class ForSem[S[_]](val expr: ForExpr[S]) extends AnyVal {
   ): Prog[F, Raw] =
     Prog
       .around(
-        N.beginScope(expr.item) >> V.valueToModel(expr.iterable).flatMap[Option[ValueRaw]] {
+        N.beginScope(expr.item) >> V.valueToRaw(expr.iterable).flatMap[Option[ValueRaw]] {
           case Some(vm) =>
             vm.lastType match {
               case t: BoxType =>

--- a/semantics/src/main/scala/aqua/semantics/expr/func/IfSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/IfSem.scala
@@ -23,9 +23,9 @@ class IfSem[S[_]](val expr: IfExpr[S]) extends AnyVal {
   ): Prog[Alg, Raw] =
     Prog
       .around(
-        V.valueToModel(expr.left).flatMap {
+        V.valueToRaw(expr.left).flatMap {
           case Some(lt) =>
-            V.valueToModel(expr.right).flatMap {
+            V.valueToRaw(expr.right).flatMap {
               case Some(rt) =>
                 T.ensureTypeMatches(expr.right, lt.lastType, rt.lastType)
                   .map(m => Some(lt -> rt).filter(_ => m))

--- a/semantics/src/main/scala/aqua/semantics/expr/func/OnSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/OnSem.scala
@@ -29,7 +29,7 @@ class OnSem[S[_]](val expr: OnExpr[S]) extends AnyVal {
         V.ensureIsString(expr.peerId),
         Traverse[List]
           .traverse(expr.via)(v =>
-            V.valueToModel(v).flatTap {
+            V.valueToRaw(v).flatTap {
               case Some(vm) =>
                 vm.lastType match {
                   case _: BoxType =>
@@ -48,7 +48,7 @@ class OnSem[S[_]](val expr: OnExpr[S]) extends AnyVal {
       (viaVM: List[ValueRaw], ops: Raw) =>
         A.endScope() >> (ops match {
           case op: FuncOp =>
-            V.valueToModel(expr.peerId).map {
+            V.valueToRaw(expr.peerId).map {
               case Some(om) =>
                 FuncOp.wrap(
                   OnTag(

--- a/semantics/src/main/scala/aqua/semantics/expr/func/PushToStreamSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/PushToStreamSem.scala
@@ -44,7 +44,7 @@ class PushToStreamSem[S[_]](val expr: PushToStreamExpr[S]) extends AnyVal {
     T: TypesAlgebra[S, Alg],
     V: ValuesAlgebra[S, Alg]
   ): Prog[Alg, Raw] =
-    V.valueToModel(expr.value).flatMap {
+    V.valueToRaw(expr.value).flatMap {
       case Some(vm) =>
         N.read(expr.stream).flatMap {
           case None => Raw.error("Cannot resolve stream type").pure[Alg]

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ReturnSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ReturnSem.scala
@@ -20,7 +20,7 @@ class ReturnSem[S[_]](val expr: ReturnExpr[S]) extends AnyVal {
     T: TypesAlgebra[S, Alg]
   ): Prog[Alg, Raw] =
     expr.values
-      .traverse(v => V.valueToModel(v).map(_.map(v -> _)))
+      .traverse(v => V.valueToRaw(v).map(_.map(v -> _)))
       .map(_.toList.flatten)
       .map(NonEmptyList.fromList)
       .flatMap {

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -35,9 +35,9 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](implicit
     }
 
   def resolveType(v: Value[S]): Alg[Option[Type]] =
-    valueToModel(v).map(_.map(_.lastType))
+    valueToRaw(v).map(_.map(_.lastType))
 
-  def valueToModel(v: Value[S]): Alg[Option[ValueRaw]] =
+  def valueToRaw(v: Value[S]): Alg[Option[ValueRaw]] =
     v match {
       case l: Literal[S] => Some(LiteralRaw(l.value, l.ts)).pure[Alg]
       case VarLambda(name, ops) =>

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
@@ -23,7 +23,8 @@ trait TypesAlgebra[S[_], Alg[_]] {
 
   def defineAlias(name: CustomTypeToken[S], target: Type): Alg[Boolean]
 
-  def resolveLambda(root: Type, ops: List[LambdaOp[S]]): Alg[List[LambdaRaw]]
+  def resolveIndex(rootT: Type, op: IntoIndex[S], idx: ValueRaw): Alg[Option[LambdaRaw]]
+  def resolveField(rootT: Type, op: IntoField[S]): Alg[Option[LambdaRaw]]
 
   def ensureTypeMatches(token: Token[S], expected: Type, givenType: Type): Alg[Boolean]
 

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesState.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesState.scala
@@ -67,7 +67,7 @@ case class TypesState[S[_]](
           dt
         }
         Option.when(strictRes.length == res.length && strictArgs.length == args.length)(
-          ArrowType(ProductType(strictArgs), ProductType(strictRes.toList))
+          ArrowType(ProductType(strictArgs), ProductType(strictRes))
         )
     }
 
@@ -118,7 +118,7 @@ case class TypesState[S[_]](
               .flatMap(t => resolveOps(t, tail).map(IntoFieldRaw(i.value, t) :: _))
           case _ => Left(i -> s"Expected product to resolve a field, got $rootT")
         }
-      case (i @ IntoIndex(_)) :: tail =>
+      case (i @ IntoIndex(idx)) :: tail =>
         rootT match {
           case ArrayType(intern) =>
             resolveOps(intern, tail).map(IntoIndexRaw(LiteralRaw.number(i.value), intern) :: _)


### PR DESCRIPTION
Fixes #329 

To use non-literal indices, the new brackets syntax is introduced:

```python

opt: []string

-- Take an element of an array, or 0 element
opt!

-- Take the sixth element
opt!5 

-- the same as opt!
opt[0]

-- the same as opt!5
opt[5]

-- get by index
func get(idx: i16) -> string:
   <- opt[idx]

-- Can use any proper value getter as an argument
get(opt!)

data Complex:
  field: []i16

func other(c: Complex) -> string
  x <- get(c.field!55)
  <- x

```