### PR TITLE
Arguments from the console did not pass to air

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,6 +2,7 @@ version = 3.3.1
 runner.dialect = scala3
 
 docstrings.style = Asterisk
+docstrings.wrap = no
 
 maxColumn = 100
 

--- a/cli/.js/src/main/scala/aqua/builder/ArgumentGetter.scala
+++ b/cli/.js/src/main/scala/aqua/builder/ArgumentGetter.scala
@@ -5,14 +5,14 @@ import aqua.js.{CallJsFunction, CallServiceHandler, FluencePeer}
 import aqua.model.{LiteralModel, VarModel}
 import aqua.raw.ops
 import aqua.raw.ops.{Call, CallServiceTag}
-import aqua.raw.value.LiteralRaw
+import aqua.raw.value.{LiteralRaw, VarRaw}
 
 import scalajs.js
 import scala.concurrent.Promise
 
 // Service that can return argument to use it from a code
-case class ArgumentGetter(serviceId: String, value: VarModel, arg: scalajs.js.Dynamic)
-  extends ServiceFunction {
+case class ArgumentGetter(serviceId: String, value: VarRaw, arg: scalajs.js.Dynamic)
+    extends ServiceFunction {
 
   def registerService(peer: FluencePeer): Unit = {
     CallJsFunction.registerService(
@@ -44,6 +44,6 @@ object ArgumentGetter {
 
   val ServiceId = "getDataSrv"
 
-  def apply(value: VarModel, arg: scalajs.js.Dynamic): ArgumentGetter =
+  def apply(value: VarRaw, arg: scalajs.js.Dynamic): ArgumentGetter =
     ArgumentGetter(ServiceId, value, arg)
 }

--- a/cli/.js/src/main/scala/aqua/run/RunOpts.scala
+++ b/cli/.js/src/main/scala/aqua/run/RunOpts.scala
@@ -126,7 +126,7 @@ object RunOpts extends Logging {
     args: List[ValueRaw],
     data: Option[js.Dynamic]
   ): ValidatedNec[String, Map[String, ArgumentGetter]] = {
-    val vars = args.collect { case v @ VarModel(_, _, _) =>
+    val vars = args.collect { case v @ VarRaw(_, _, _) =>
       v
     // one variable could be used multiple times
     }.distinctBy(_.name)

--- a/cli/.js/src/main/scala/aqua/run/Runner.scala
+++ b/cli/.js/src/main/scala/aqua/run/Runner.scala
@@ -18,11 +18,11 @@ import scala.concurrent.ExecutionContext
 import scala.scalajs.js
 
 class Runner(
-              funcName: String,
-              funcCallable: FuncArrow,
-              args: List[ValueRaw],
-              config: RunConfig,
-              transformConfig: TransformConfig
+  funcName: String,
+  funcCallable: FuncArrow,
+  args: List[ValueRaw],
+  config: RunConfig,
+  transformConfig: TransformConfig
 ) {
 
   def resultVariableNames(funcCallable: FuncArrow, name: String): List[String] =
@@ -54,9 +54,9 @@ class Runner(
 
   // Generates air from function, register all services and make a call through FluenceJS
   private def genAirAndMakeCall[F[_]: Async](
-                                              wrapped: FuncArrow,
-                                              consoleService: Console,
-                                              finisherService: Finisher
+    wrapped: FuncArrow,
+    consoleService: Console,
+    finisherService: Finisher
   )(implicit ec: ExecutionContext): F[Unit] = {
     val funcRes = Transform.funcRes(wrapped, transformConfig)
     val definitions = FunctionDef(funcRes)
@@ -134,7 +134,7 @@ class Runner(
 
     val vars = args
       .zip(funcCallable.arrowType.domain.toList)
-      .collect { case (VarModel(n, _, _), argType) =>
+      .collect { case (VarRaw(n, _, _), argType) =>
         (n, argType)
       }
       .distinctBy(_._1)


### PR DESCRIPTION
Variables were not registered in air
```
aqua run -i aqua-scripts -a /dns4/kras-00.fluence.dev/tcp/19990/wss/p2p/12D3KooWSD5PToNiLQwKDXsu8JSysCwUt8BVUJEqCHcDe7P5h45e -f 'add_one(arg1, arg2, arg3)' --data '{"arg1": 5, "arg2": "12D3KooWFtf3rfCDAfWwt6oLZYZbDfn9Vn7bv7g6QjjQxUUEFVBt", "arg3": "7b2ab89f-0897-4537-b726-8120b405074d"}'
Your peerId: 12D3KooWMHpKgiGaduHWhW3pJdCEoQUjR8wrQsZm1cKxhkrgxB8L
Interpreter failed:  {
    "retCode": 1,
    "errorMessage": "air can't be parsed:\nerror: \n   ┌─ script.air:11:7\n   │\n11 │       (call arg2 (arg3 \"add_one\") [arg1] res)\n   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n   │       │\n   │       variable 'arg2' wasn't defined\n   │       variable 'arg3' wasn't defined\n   │       variable 'arg1' wasn't defined\n\n",
    "data": "",
    "nextPeerPks": [],
    "callRequests": []
}
```