### PR TITLE
Use `noop` call on `join`

### DIFF
--- a/model/transform/src/main/scala/aqua/model/transform/res/MakeRes.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/res/MakeRes.scala
@@ -54,7 +54,7 @@ object MakeRes {
     leaf(
       CallServiceRes(
         op,
-        "identity",
+        "noop",
         CallRes(operands.toList, None),
         onPeer
       )


### PR DESCRIPTION
`identity` doesn't support multiple arguments. Change to `noop`