### PR TITLE
Add timeout to finisher to avoid infinite hanging of async functions

### DIFF
--- a/npm/aqua/dist.aqua
+++ b/npm/aqua/dist.aqua
@@ -12,7 +12,11 @@ data ModuleConf:
   mounted_binaries: ?[][]string
   preopened_files: ?[]string
   mapped_dirs: ?[][]string
+  envs: ?[][]string
   logger_enabled: ?bool
+  logging_mask: ?i32
+  mem_pages_count: ?u32
+  max_heap_size: ?string
 
 data ServiceConf:
   modules: []ModuleConf
@@ -48,7 +52,7 @@ func deploy(serviceName: string, serviceConf: ServiceConf) -> string:
 --      Console.print(hostRes.path)
 --      on ON_PEER:
 
-        conf <- Dist.make_module_config(m.name, nil, nil, m.logger_enabled, m.preopened_files, nil, m.mapped_dirs, m.mounted_binaries, nil)
+        conf <- Dist.make_module_config(m.name, m.mem_pages_count, m.max_heap_size, m.logger_enabled, m.preopened_files, m.envs, m.mapped_dirs, m.mounted_binaries, m.logging_mask)
 
 --      Console.print("Created config")
 

--- a/npm/src/config.ts
+++ b/npm/src/config.ts
@@ -5,7 +5,11 @@ type Module = {
     mounted_binaries: string[][],
     logger_enabled: boolean[],
     preopened_files: string[],
-    mapped_dirs: string[]
+    envs: string[][],
+    mapped_dirs: string[],
+    logging_mask?: number,
+    mem_pages_count?: number,
+    max_heap_size?: string
 }
 
 type Config = {
@@ -26,6 +30,18 @@ export function fillWithEmptyArrays(config: Config): Config {
         }
         if (!m.mapped_dirs) {
             m.mapped_dirs = []
+        }
+        if (!m.envs) {
+            m.envs = []
+        }
+        if (!m.logging_mask) {
+            m.logging_mask = []
+        }
+        if (!m.mem_pages_count) {
+            m.mem_pages_count = []
+        }
+        if (!m.max_heap_size) {
+            m.max_heap_size = []
         }
         return m
     })

--- a/npm/src/config.ts
+++ b/npm/src/config.ts
@@ -7,9 +7,9 @@ type Module = {
     preopened_files: string[],
     envs: string[][],
     mapped_dirs: string[],
-    logging_mask?: number,
-    mem_pages_count?: number,
-    max_heap_size?: string
+    logging_mask: number[],
+    mem_pages_count: number[],
+    max_heap_size: string[]
 }
 
 type Config = {


### PR DESCRIPTION
fixes #436 

also adds missed fields to ModuleConfig in `aqua dist deploy`, related to #421 