### PR TITLE
Add top-bottom support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val scribeV = "3.6.3"
 name := "aqua-hll"
 
 val commons = Seq(
-  baseAquaVersion := "0.6.1",
+  baseAquaVersion := "0.6.2",
   version         := baseAquaVersion.value + "-" + sys.env.getOrElse("BUILD_NUMBER", "SNAPSHOT"),
   scalaVersion    := dottyVersion,
   libraryDependencies ++= Seq(

--- a/cli/.js/src/main/scala/aqua/builder/Console.scala
+++ b/cli/.js/src/main/scala/aqua/builder/Console.scala
@@ -24,7 +24,10 @@ object Console {
     override def fnName: String = funcName
 
     def handler: ServiceHandler = { varArgs =>
-      OutputPrinter.print(JSON.stringify(varArgs(0), space = 2))
+      js.typeOf(varArgs(0)) match {
+        case "string" | "number" | "boolean" => OutputPrinter.print(varArgs(0).toString)
+        case _ => OutputPrinter.print(JSON.stringify(varArgs(0), space = 2))
+      }
       js.Promise.resolve(Service.emptyObject)
     }
     def argDefinitions: List[ArgDefinition] = ArgDefinition("str", PrimitiveType) :: Nil

--- a/parser/src/main/scala/aqua/parser/lexer/TypeToken.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/TypeToken.scala
@@ -98,9 +98,9 @@ object BasicTypeToken {
 }
 
 case class ArrowTypeToken[S[_]: Comonad](
-                                          override val unit: S[Unit],
-                                          args: List[(Option[Name[S]], TypeToken[S])],
-                                          res: List[DataTypeToken[S]]
+  override val unit: S[Unit],
+  args: List[(Option[Name[S]], TypeToken[S])],
+  res: List[DataTypeToken[S]]
 ) extends TypeToken[S] {
   override def as[T](v: T): S[T] = unit.as(v)
 
@@ -143,18 +143,18 @@ object DataTypeToken {
 
   val `withoutstreamdatatypedef`: P[DataTypeToken[Span.S]] =
     P.oneOf(
-      P.defer(`arraytypedef`) :: P.defer(
+      P.defer(`topbottomdef`) :: P.defer(`arraytypedef`) :: P.defer(
         OptionTypeToken.`optiontypedef`
-      ) :: BasicTypeToken
-        .`basictypedef` :: CustomTypeToken.dotted :: Nil
+      ) :: BasicTypeToken.`basictypedef` :: CustomTypeToken.dotted :: Nil
     )
 
   def `datatypedef`: P[DataTypeToken[Span.S]] =
     P.oneOf(
-      P.defer(`arraytypedef`) :: P.defer(StreamTypeToken.`streamtypedef`) :: P.defer(
+      P.defer(`topbottomdef`) :: P.defer(`arraytypedef`) :: P.defer(
+        StreamTypeToken.`streamtypedef`
+      ) :: P.defer(
         OptionTypeToken.`optiontypedef`
-      ) :: BasicTypeToken
-        .`basictypedef` :: CustomTypeToken.dotted :: Nil
+      ) :: BasicTypeToken.`basictypedef` :: CustomTypeToken.dotted :: Nil
     )
 
 }


### PR DESCRIPTION
Support top-bottom notation to make it possible to work with `any` type. Useful for debug tools as:
```
service Debug("debug"):
  stringify(o: ⊤) -> string
```