### PR TITLE
Empty collections creation

### DIFF
--- a/aqua-src/hack.aqua
+++ b/aqua-src/hack.aqua
@@ -1,8 +1,12 @@
-func optionSugar() -> []u32, ?u32:
-  str: *u32
-  for i <- ?[4, 5]:
-    str <<- i
-  <- str, ?[]
-
-func emptySugar() -> ?u32, []u32:
-  <- [], ?[], *[]
+func emptySugar() -> []u32, []string, []string, *string, ?u32, []u32, ?string:
+  numOp = ?[]
+  strArr = []
+  strStream = *[]
+  strEmptyStream: *string
+  for i <- ?[]:
+    strEmptyStream <<- "some"
+  for i <- *[]:
+    strEmptyStream <<- "some"
+  for i <- []:
+    strEmptyStream <<- "some"
+  <- numOp, strArr, strStream, strEmptyStream, [], ?[], *[]

--- a/aqua-src/hack.aqua
+++ b/aqua-src/hack.aqua
@@ -1,12 +1,4 @@
-func emptySugar() -> []u32, []string, []string, *string, ?u32, []u32, ?string:
-  numOp = ?[]
-  strArr = []
-  strStream = *[]
-  strEmptyStream: *string
-  for i <- ?[]:
-    strEmptyStream <<- "some"
-  for i <- *[]:
-    strEmptyStream <<- "some"
-  for i <- []:
-    strEmptyStream <<- "some"
-  <- numOp, strArr, strStream, strEmptyStream, [], ?[], *[]
+func optionSugar(numSome: ?u32, numNone: ?u32) -> []u32:
+  arr = ?[numNone!, numSome!, "123"]
+  <- arr
+

--- a/aqua-src/hack.aqua
+++ b/aqua-src/hack.aqua
@@ -3,3 +3,6 @@ func optionSugar() -> []u32, ?u32:
   for i <- ?[4, 5]:
     str <<- i
   <- str, ?[]
+
+func emptySugar() -> ?u32, []u32:
+  <- [], ?[], *[]

--- a/aqua-src/hack.aqua
+++ b/aqua-src/hack.aqua
@@ -1,5 +1,5 @@
-func optionSugar() -> []u32:
+func optionSugar() -> []u32, ?u32:
   str: *u32
   for i <- ?[4, 5]:
     str <<- i
-  <- str
+  <- str, ?[]

--- a/model/res/src/main/scala/aqua/res/MakeRes.scala
+++ b/model/res/src/main/scala/aqua/res/MakeRes.scala
@@ -43,6 +43,11 @@ object MakeRes {
   private def orInit(currentPeerId: Option[ValueModel]): ValueModel =
     currentPeerId.getOrElse(initPeerId)
 
+  private def isNillLiteral(vm: ValueModel): Boolean = vm match {
+    case LiteralModel(value, t) if value == ValueRaw.Nil.value && t == ValueRaw.Nil.`type` => true
+    case _ => false
+  }
+
   def resolve(
     currentPeerId: Option[ValueModel],
     i: Int
@@ -51,7 +56,7 @@ object MakeRes {
     case _: OnModel => SeqRes.leaf
     case MatchMismatchModel(a, b, s) =>
       MatchMismatchRes(a, b, s).leaf
-    case ForModel(item, iter) => FoldRes(item, iter).leaf
+    case ForModel(item, iter) if !isNillLiteral(iter) => FoldRes(item, iter).leaf
     case RestrictionModel(item, isStream) => RestrictionRes(item, isStream).leaf
     case ParModel | DetachModel => ParRes.leaf
     case XorModel => XorRes.leaf

--- a/parser/src/main/scala/aqua/parser/lexer/Token.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/Token.scala
@@ -87,6 +87,8 @@ object Token {
   val exclamation: P[Unit] = P.char('!')
   val `[]` : P[Unit] = P.string("[]")
   val `[` : P[Unit] = P.char('[').surroundedBy(` `.?)
+  val `*[` : P[Unit] = P.string("*[").surroundedBy(` `.?)
+  val `?[` : P[Unit] = P.string("?[").surroundedBy(` `.?)
   val `]` : P[Unit] = P.char(']').surroundedBy(` `.?)
   val `⊤` : P[Unit] = P.char('⊤')
   val `⊥` : P[Unit] = P.char('⊥')

--- a/parser/src/main/scala/aqua/parser/lexer/ValueToken.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/ValueToken.scala
@@ -34,7 +34,7 @@ case class LiteralToken[F[_]: Comonad](valueToken: F[String], ts: LiteralType)
 }
 
 case class CollectionToken[F[_]: Comonad](
-  values: NonEmptyList[ValueToken[F]],
+  values: List[ValueToken[F]],
   mode: CollectionToken.Mode
 ) extends ValueToken[F] {
   override def mapK[K[_]: Comonad](fk: F ~> K): ValueToken[K] = copy(values.map(_.mapK(fk)))
@@ -52,7 +52,7 @@ object CollectionToken {
       _.getOrElse(Mode.ArrayMode: Mode)
     ).with1 ~ (`[` *> P
       .defer(ValueToken.`_value`)
-      .repSep(`,`) <* `]`)).map { case (mode, vals) =>
+      .repSep0(`,`) <* `]`)).map { case (mode, vals) =>
       CollectionToken(vals, mode)
     }
 }

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -109,6 +109,7 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](implicit
                 }
               )
             )
+          case _ if values.isEmpty => Some(ValueRaw.Nil)  
           case _ => None
         }
     }


### PR DESCRIPTION
Use `[]` to create an empty array. Should be useful when you play with collection creation syntax, adding and removing elements from square braces.