### PR TITLE
Set arguments types dynamically from JSON

### DIFF
--- a/cli/.js/src/main/scala/aqua/ArgOpts.scala
+++ b/cli/.js/src/main/scala/aqua/ArgOpts.scala
@@ -138,6 +138,8 @@ object ArgOpts {
           .andThen { services =>
             val argsWithTypes = cliFunc.args.map {
               case v @ VarRaw(n, t) =>
+                // argument getters have been enriched with types derived from JSON
+                // put this types to unriched arguments in CliFunc
                 services.get(n).map(g => v.copy(baseType = g.function.value.baseType)).getOrElse(v)
               case v => v
             }

--- a/cli/.js/src/main/scala/aqua/ipfs/IpfsOpts.scala
+++ b/cli/.js/src/main/scala/aqua/ipfs/IpfsOpts.scala
@@ -49,10 +49,10 @@ object IpfsOpts extends Logging {
 
   def pathOpt: Opts[String] =
     Opts
-      .option[String]("path", "Path to file", "p")
+      .option[String]("path", "Path to a file", "p")
 
   def ipfsOpt[F[_]: Async]: Command[F[ExitCode]] =
-    CommandBuilder("ipfs", "Working with IPFS on peer", NonEmptyList.one(upload[F])).command
+    CommandBuilder("ipfs", "Work with IPFS on a peer", NonEmptyList.one(upload[F])).command
 
   // Uploads a file to IPFS
   def upload[F[_]: Async]: SubCommandBuilder[F] =

--- a/model/src/main/scala/aqua/model/ValueModel.scala
+++ b/model/src/main/scala/aqua/model/ValueModel.scala
@@ -89,7 +89,7 @@ case class IntoIndexModel(idx: String, `type`: Type) extends LambdaModel {
 }
 
 case class VarModel(name: String, baseType: Type, lambda: Chain[LambdaModel] = Chain.empty)
-  extends ValueModel with Logging {
+    extends ValueModel with Logging {
 
   override lazy val usesVarNames: Set[String] =
     lambda.toList.map(_.usesVarNames).foldLeft(Set(name))(_ ++ _)
@@ -123,7 +123,7 @@ case class VarModel(name: String, baseType: Type, lambda: Chain[LambdaModel] = C
                     res <- two(variable)
                     <- variable
                */
-              case vm@VarModel(nn, _, _) if nn == name => deriveFrom(vm)
+              case vm @ VarModel(nn, _, _) if nn == name => deriveFrom(vm)
               // it couldn't go to a cycle as long as the semantics protects it
               case _ =>
                 n.resolveWith(vals) match {


### PR DESCRIPTION
It fixes types resolving in `aqua run` for a case where argument uses for `via` route