### PR TITLE
Show parser error if constant is an array, function call, or expression

### DIFF
--- a/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
@@ -38,15 +38,15 @@ object ConstantExpr extends Expr.Leaf {
         value match {
           case CollectionToken(point, _) =>
             P.failWith(
-              "The constant cannot be an array. It can only be a string, a number, or a boolean."
+              s"'$name' is an array, but only strings, numbers or booleans can be used"
             )
           case CallArrowToken(_, _, _) =>
             P.failWith(
-              "The constant cannot be a function call. It can only be a string, a number, or a boolean."
+              s"'$name' is a function call, but only strings, numbers or booleans can be used"
             )
           case InfixToken(_, _, _) =>
             P.failWith(
-              "The constant cannot be an expression. It can only be a string, a number, or a boolean."
+              s"'$name' an expression, but only strings, numbers or booleans can be used"
             )
           case _ =>
             P.pure(ConstantExpr(name, value, mark.nonEmpty))

--- a/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
@@ -37,11 +37,13 @@ object ConstantExpr extends Expr.Leaf {
       case ((name, mark), value) =>
         value match {
           case CollectionToken(point, _) =>
-            P.failWith("The constant cannot be an array")
+            P.failWith("The constant cannot be an array. It can only be a number or a string.")
           case CallArrowToken(_, _, _) =>
-            P.failWith("The constant cannot be a function call")
+            P.failWith(
+              "The constant cannot be a function call. It can only be a number or a string."
+            )
           case InfixToken(_, _, _) =>
-            P.failWith("The constant cannot be an expression")
+            P.failWith("The constant cannot be an expression. It can only be a number or a string.")
           case _ =>
             P.pure(ConstantExpr(name, value, mark.nonEmpty))
         }

--- a/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
@@ -37,13 +37,17 @@ object ConstantExpr extends Expr.Leaf {
       case ((name, mark), value) =>
         value match {
           case CollectionToken(point, _) =>
-            P.failWith("The constant cannot be an array. It can only be a number or a string.")
+            P.failWith(
+              "The constant cannot be an array. It can only be a string, a number, or a boolean."
+            )
           case CallArrowToken(_, _, _) =>
             P.failWith(
-              "The constant cannot be a function call. It can only be a number or a string."
+              "The constant cannot be a function call. It can only be a string, a number, or a boolean."
             )
           case InfixToken(_, _, _) =>
-            P.failWith("The constant cannot be an expression. It can only be a number or a string.")
+            P.failWith(
+              "The constant cannot be an expression. It can only be a string, a number, or a boolean."
+            )
           case _ =>
             P.pure(ConstantExpr(name, value, mark.nonEmpty))
         }

--- a/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
@@ -37,11 +37,11 @@ object ConstantExpr extends Expr.Leaf {
       case ((name, mark), value) =>
         value match {
           case CollectionToken(point, _) =>
-            P.failWith("Constant cannot be an array")
+            P.failWith("The constant cannot be an array")
           case CallArrowToken(_, _, _) =>
-            P.failWith("Constant cannot be a function call")
+            P.failWith("The constant cannot be a function call")
           case InfixToken(_, _, _) =>
-            P.failWith("Constant cannot be an expression")
+            P.failWith("The constant cannot be an expression")
           case _ =>
             P.pure(ConstantExpr(name, value, mark.nonEmpty))
         }

--- a/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/ConstantExpr.scala
@@ -2,7 +2,14 @@ package aqua.parser.expr
 
 import aqua.parser.Expr
 import aqua.parser.lexer.Token.*
-import aqua.parser.lexer.{LiteralToken, Name, ValueToken}
+import aqua.parser.lexer.{
+  CallArrowToken,
+  CollectionToken,
+  InfixToken,
+  LiteralToken,
+  Name,
+  ValueToken
+}
 import aqua.parser.lift.LiftParser
 import cats.Comonad
 import cats.parse.Parser as P
@@ -11,9 +18,9 @@ import aqua.parser.lift.Span
 import aqua.parser.lift.Span.{P0ToSpan, PToSpan}
 
 case class ConstantExpr[F[_]](
-                               name: Name[F],
-                               value: ValueToken[F],
-                               skipIfAlreadyDefined: Boolean
+  name: Name[F],
+  value: ValueToken[F],
+  skipIfAlreadyDefined: Boolean
 ) extends Expr[F](ConstantExpr, name) {
 
   def mapK[K[_]: Comonad](fk: F ~> K): ConstantExpr[K] =
@@ -21,20 +28,28 @@ case class ConstantExpr[F[_]](
 }
 
 object ConstantExpr extends Expr.Leaf {
-  
+
   private val constName: P[Name[Span.S]] =
     `const` *> ` ` *> Name.upper.withContext("Constant's names must be in UPPERCASE") <* ` `
-  
 
   override val p: P[ConstantExpr[Span.S]] =
-    (((constName ~ `?`.?).with1 <* `=` <* ` `) ~ ValueToken.`value`)
-    .map { case ((name, mark), value) =>
-      ConstantExpr(name, value, mark.nonEmpty)
+    (((constName ~ `?`.?).with1 <* `=` <* ` `) ~ ValueToken.`value`).flatMap {
+      case ((name, mark), value) =>
+        value match {
+          case CollectionToken(point, _) =>
+            P.failWith("Constant cannot be an array")
+          case CallArrowToken(_, _, _) =>
+            P.failWith("Constant cannot be a function call")
+          case InfixToken(_, _, _) =>
+            P.failWith("Constant cannot be an expression")
+          case _ =>
+            P.pure(ConstantExpr(name, value, mark.nonEmpty))
+        }
+
     }
 
   val onlyLiteral: P[(Name[Span.S], LiteralToken[Span.S])] =
-    ((((Name
-      .upper <* ` `) ~ `?`.?).with1 <* `=` <* ` `) ~ ValueToken.literal).map {
+    ((((Name.upper <* ` `) ~ `?`.?).with1 <* `=` <* ` `) ~ ValueToken.literal).map {
       case ((name, _), value) =>
         (name, value)
     }


### PR DESCRIPTION
Arrays are not literals and need to generate operations in air code. It is unclear right now how to do this properly. This PR will add clear error messages for this.
```
---- Syntax error: /home/diemust/git/aqua/npm/test/sample.aqua:20:26
20 const AAA = ["a", "b"]
                            ^
                            The constant cannot be an array

```