### PR TITLE
Pass arrays as arguments in `aqua run` function call

### DIFF
--- a/cli/.js/src/main/scala/aqua/ArgOpts.scala
+++ b/cli/.js/src/main/scala/aqua/ArgOpts.scala
@@ -76,7 +76,7 @@ object ArgOpts {
 
                 } else
                   invalidNel(
-                    "Array arguments with variables are not supported. Use only numbers or strings."
+                    "Array arguments with variables are not supported. Use only numbers, strings, or booleans."
                   )
               case CallArrowToken(_, _, _) =>
                 invalidNel("Function call as argument not supported.")

--- a/cli/.js/src/main/scala/aqua/ArgOpts.scala
+++ b/cli/.js/src/main/scala/aqua/ArgOpts.scala
@@ -74,7 +74,10 @@ object ArgOpts {
                       "If the argument is an array, then it must contain elements of the same type."
                     )
 
-                } else invalidNel("Array arguments with variables are not supported.")
+                } else
+                  invalidNel(
+                    "Array arguments with variables are not supported. Use only numbers or strings."
+                  )
               case CallArrowToken(_, _, _) =>
                 invalidNel("Function call as argument not supported.")
             }.sequence

--- a/cli/.js/src/main/scala/aqua/ArgOpts.scala
+++ b/cli/.js/src/main/scala/aqua/ArgOpts.scala
@@ -76,7 +76,7 @@ object ArgOpts {
 
                 } else
                   invalidNel(
-                    "Array arguments with variables are not supported. Use only numbers, strings, or booleans."
+                    "Array arguments can only have numbers, strings, or booleans."
                   )
               case CallArrowToken(_, _, _) =>
                 invalidNel("Function call as argument not supported.")


### PR DESCRIPTION
Example:
```
aqua run -f 'someFunc(["str", "another str"])'
```