### PR TITLE
LNG-64 Configurable log-level argument

### DIFF
--- a/cli/.js/src/main/scala/aqua/CommandBuilder.scala
+++ b/cli/.js/src/main/scala/aqua/CommandBuilder.scala
@@ -48,7 +48,7 @@ class SubCommandBuilder[F[_]: Async](
     opts.map { riF =>
       riF.flatMap {
         case Validated.Valid(ri) =>
-          LogFormatter.initLogger(Some(ri.common.logLevel))
+          LogFormatter.initLogger(Some(ri.common.logLevel.compiler))
           (ri.input match {
             case PackagePath(p) => PlatformOpts.getPackagePath(p)
             case RelativePath(p) => p.pure[F]

--- a/cli/.js/src/main/scala/aqua/LogLevelTransformer.scala
+++ b/cli/.js/src/main/scala/aqua/LogLevelTransformer.scala
@@ -1,6 +1,6 @@
 package aqua
 
-import aqua.js.{AvmLogLevel, FluenceJSLogLevel, Meta, Module}
+import aqua.js.{LogLevel, FluenceJSLogLevel, Meta, Module}
 import fs2.io.file.Path
 import scribe.Level
 
@@ -8,7 +8,7 @@ import scala.util.Try
 
 object LogLevelTransformer {
 
-  def logLevelToAvm(logLevel: Level): AvmLogLevel = {
+  def logLevelToAvm(logLevel: Level): LogLevel = {
     logLevel match {
       case Level.Trace => "trace"
       case Level.Debug => "debug"

--- a/cli/.js/src/main/scala/aqua/js/FluenceJsTypes.scala
+++ b/cli/.js/src/main/scala/aqua/js/FluenceJsTypes.scala
@@ -204,16 +204,15 @@ object NamesConfigJs {
   }
 }
 
-type AvmLogLevel = "trace" | "debug" | "info" | "warn" | "error" | "off"
+type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "off"
 
 @JSExportAll
-case class Debug(printParticleId: js.UndefOr[Boolean])
+case class Debug(printParticleId: js.UndefOr[Boolean], marineLogLevel: js.UndefOr[LogLevel])
 
 @JSExportAll
 case class PeerConfig(
   connectTo: String,
   defaultTtlMs: js.UndefOr[Int],
-  avmLogLevel: AvmLogLevel,
   KeyPair: KeyPair,
   debug: js.UndefOr[Debug]
 )

--- a/cli/.js/src/main/scala/aqua/run/RunCommand.scala
+++ b/cli/.js/src/main/scala/aqua/run/RunCommand.scala
@@ -119,7 +119,7 @@ object RunCommand extends Logging {
     inputPath: Path
   ): F[ValidatedNec[String, Unit]] = {
     val common = runInfo.common
-    LogFormatter.initLogger(Some(common.logLevel))
+    LogFormatter.initLogger(Some(common.logLevel.compiler))
     implicit val aio: AquaIO[F] = new AquaFilesIO[F]
 
     RunCommand

--- a/cli/.js/src/main/scala/aqua/run/RunConfig.scala
+++ b/cli/.js/src/main/scala/aqua/run/RunConfig.scala
@@ -1,6 +1,6 @@
 package aqua.run
 
-import aqua.{AppOpts, VarJson}
+import aqua.{AppOpts, LogLevels, VarJson}
 import aqua.FluenceOpts.*
 import aqua.builder.{ArgumentGetter, Service}
 import aqua.config.ConfigOpts.{Krasnodar, Stage, TestNet}
@@ -27,7 +27,7 @@ case class Flags(
 
 case class GeneralRunOptions(
   timeout: Option[Int],
-  logLevel: Level,
+  logLevel: LogLevels,
   multiaddr: String,
   on: Option[String],
   flags: Flags,
@@ -88,7 +88,7 @@ object GeneralRunOptions {
   ): Opts[GeneralRunOptions] =
     (
       AppOpts.wrapWithOption(timeoutOpt),
-      logLevelOpt.withDefault(Level.Fatal),
+      logLevelOpt.withDefault(LogLevels()),
       multiaddrOpt,
       onOpt,
       flagsOpt(isRun),

--- a/cli/.js/src/main/scala/aqua/run/RunOpts.scala
+++ b/cli/.js/src/main/scala/aqua/run/RunOpts.scala
@@ -84,7 +84,7 @@ object RunOpts extends Logging {
               common,
               optionsF
             ) =>
-          LogFormatter.initLogger(Some(common.logLevel))
+          LogFormatter.initLogger(Some(common.logLevel.compiler))
           optionsF.map(
             _.map { case (input, imps, funcWithArgs, services) =>
               RunInfo(

--- a/cli/src/main/scala/aqua/FluenceOpts.scala
+++ b/cli/src/main/scala/aqua/FluenceOpts.scala
@@ -25,7 +25,7 @@ object LogLevels {
   }
 
   lazy val error =
-    "Invalid log level format. Must be: '<log-level>' or 'compiler=<log-level>,fluencejs=<log-level>,aquavm=<log-level>', where <log-level> is one of these strings: 'all', 'trace', 'debug', 'info', 'warn', 'error', 'off'"
+    "Invalid log-level format. Must be: '<log-level>' or 'compiler=<log-level>,fluencejs=<log-level>,aquavm=<log-level>', where <log-level> is one of these strings: 'all', 'trace', 'debug', 'info', 'warn', 'error', 'off'"
 
   private def fromStrings(name: String, level: String, logLevels: LogLevels): Validated[NonEmptyList[String], LogLevels] = {
     levelFromString(level).andThen { level =>
@@ -41,6 +41,8 @@ object LogLevels {
     }
   }
 
+  // Format: '<log-level>' or 'compiler=<log-level>,fluencejs=<log-level>,aquavm=<log-level>',
+  // where <log-level> is one of these strings: 'all', 'trace', 'debug', 'info', 'warn', 'error', 'off'
   def fromString(s: String): ValidatedNel[String, LogLevels] = {
     s.split(",").toList match {
       case l :: Nil =>

--- a/cli/src/main/scala/aqua/FluenceOpts.scala
+++ b/cli/src/main/scala/aqua/FluenceOpts.scala
@@ -1,10 +1,68 @@
 package aqua
 
-import cats.data.{NonEmptyList, Validated}
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
 import com.monovore.decline.Opts
 import scribe.Level
+import cats.syntax.traverse.*
+import cats.data.Validated.{invalid, invalidNec, invalidNel, valid, validNec, validNel}
 
 import java.util.Base64
+
+case class LogLevels(compiler: Level = Level.Info, fluencejs: Level = Level.Info, aquavm: Level = Level.Info)
+
+object LogLevels {
+  def apply(level: Level): LogLevels = LogLevels(level, level, level)
+
+  private def levelFromString(s: String): ValidatedNel[String, Level] = {
+    LogLevel.stringToLogLevel
+      .get(s.toLowerCase)
+      .map(validNel)
+      .getOrElse(
+        invalidNel(
+          s"Unknown log-level '$s'. Please use one of these: 'all', 'trace', 'debug', 'info', 'warn', 'error', 'off'"
+        )
+      )
+  }
+
+  lazy val error =
+    "Invalid log level format. Must be: '<log-level>' or 'compiler=<log-level>,fluencejs=<log-level>,aquavm=<log-level>', where <log-level> is one of these strings: 'all', 'trace', 'debug', 'info', 'warn', 'error', 'off'"
+
+  private def fromStrings(name: String, level: String, logLevels: LogLevels): Validated[NonEmptyList[String], LogLevels] = {
+    levelFromString(level).andThen { level =>
+      name match {
+        case "compiler" =>
+          validNel(logLevels.copy(compiler = level))
+        case "fluencejs" =>
+          validNel(logLevels.copy(fluencejs = level))
+        case "aquavm" =>
+          validNel(logLevels.copy(aquavm = level))
+        case s => invalidNel[String, LogLevels](s"Unknown component '$s' in log-level. Please use one of these: 'aquavm', 'compiler' and 'fluencejs'")
+      }
+    }
+  }
+
+  def fromString(s: String): ValidatedNel[String, LogLevels] = {
+    s.split(",").toList match {
+      case l :: Nil =>
+        l.split("=").toList match {
+          case n :: ll :: Nil => fromStrings(n, ll, LogLevels())
+          case ll :: Nil => levelFromString(ll).map(apply)
+          case _ => invalidNel(error)
+        }
+
+      case arr =>
+        arr.foldLeft(validNel[String, LogLevels](LogLevels())) { case (logLevelV, ss) =>
+          logLevelV.andThen { logLevels =>
+              ss.split("=").toList match {
+                case n :: ll :: Nil => fromStrings(n, ll, logLevels)
+                case _ => invalidNel[String, LogLevels](error)
+              }
+          }
+        }
+
+    }
+  }
+}
 
 object FluenceOpts {
 
@@ -15,7 +73,12 @@ object FluenceOpts {
   val onOpt: Opts[Option[String]] =
     AppOpts.wrapWithOption(
       Opts
-        .option[String]("on", "peerId of the peer that will execute the function. Default: host_peer_id", "o", "peerId")
+        .option[String](
+          "on",
+          "peerId of the peer that will execute the function. Default: host_peer_id",
+          "o",
+          "peerId"
+        )
     )
 
   val showConfigOpt: Opts[Boolean] =
@@ -46,21 +109,9 @@ object FluenceOpts {
       .map(_ => true)
       .withDefault(false)
 
-  val logLevelOpt: Opts[Level] =
+  val logLevelOpt: Opts[LogLevels] =
     Opts.option[String]("log-level", help = "Set log level").withDefault("info").mapValidated {
       str =>
-        Validated.fromEither(toLogLevel(str))
+        LogLevels.fromString(str)
     }
-
-  def toLogLevel(logLevel: String): Either[NonEmptyList[String], Level] = {
-    LogLevel.stringToLogLevel
-      .get(logLevel.toLowerCase)
-      .toRight(
-        NonEmptyList(
-          // TODO: maybe print the log level user tried to use inside the error message
-          "Unknown log-level. Please use one of these: 'all', 'trace', 'debug', 'info', 'warn', 'error', 'off'",
-          Nil
-        )
-      )
-  }
 }

--- a/cli/src/main/scala/aqua/FluenceOpts.scala
+++ b/cli/src/main/scala/aqua/FluenceOpts.scala
@@ -57,6 +57,7 @@ object LogLevels {
           logLevelV.andThen { logLevels =>
               ss.split("=").toList match {
                 case n :: ll :: Nil => fromStrings(n, ll, logLevels)
+                case n :: Nil => levelFromString(n).map(apply)
                 case _ => invalidNel[String, LogLevels](error)
               }
           }
@@ -114,6 +115,9 @@ object FluenceOpts {
   val logLevelOpt: Opts[LogLevels] =
     Opts.option[String]("log-level", help = "Set log level").withDefault("info").mapValidated {
       str =>
-        LogLevels.fromString(str)
+        LogLevels.fromString(str).map{ f =>
+          println(f)
+          f
+        }
     }
 }


### PR DESCRIPTION
Format: `'<log-level>' or 'compiler=<log-level>,fluencejs=<log-level>,aquavm=<log-level>', where <log-level> is one of these strings: 'all', 'trace', 'debug', 'info', 'warn', 'error', 'off'`