### PR TITLE
chore(release-please): Set aqua-api version in tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,11 @@ jobs:
         run: pnpm version ${{ steps.version.outputs.version }}
         working-directory: language-server/language-server-npm
 
+      - name: Set aqua version in tests
+        run: |
+          pnpm add @fluencelabs/aqua-api@${{ steps.version.outputs.version }} --save-workspace-protocol=false
+        working-directory: integration-tests
+
       - name: Regenerate lock
         run: pnpm -r i
 


### PR DESCRIPTION
Bump aqua-api npm version in release-please PR to use aqua-api from workspace.