### PR TITLE
fix(compiler): Fix topology for adjacent `on`s [LNG-257]

### DIFF
--- a/integration-tests/aqua/examples/topology.aqua
+++ b/integration-tests/aqua/examples/topology.aqua
@@ -1,4 +1,4 @@
-aqua Toplogy
+aqua Topology
 
 export Testo, LocalPrint, topologyTest, topologyBug205, topologyBug394, topologyBug427, topologyBug257
 

--- a/integration-tests/aqua/examples/topology.aqua
+++ b/integration-tests/aqua/examples/topology.aqua
@@ -1,3 +1,7 @@
+aqua Toplogy
+
+export Testo, LocalPrint, topologyTest, topologyBug205, topologyBug394, topologyBug427, topologyBug257
+
 import "@fluencelabs/aqua-lib/builtin.aqua"
 
 service Testo("testo"):
@@ -51,3 +55,22 @@ func topologyBug427(peers: []string) -> []string:
 
     join results[1]
     <- results
+
+service StrOp("op"):
+    identity(str: string) -> string
+
+func idOnPeer(friend: string, friendRelay: string, str: string) -> string:
+    on friend via friendRelay:
+        result <- StrOp.identity(str)
+
+    <- result
+
+func topologyBug257(friend: string, friendRelay: string) -> []string:
+    result: *string
+
+    on HOST_PEER_ID:
+        result <- StrOp.identity("host")
+        result <- idOnPeer(friend, friendRelay, "friend")
+        result <- idOnPeer(INIT_PEER_ID, HOST_PEER_ID, "init")
+    
+    <- result

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -51,6 +51,7 @@ import {
   topologyBug205Call,
   topologyBug394Call,
   topologyBug427Call,
+  topologyBug257Call,
   topologyCall,
 } from "../examples/topologyCall.js";
 import { foldJoinCall } from "../examples/foldJoinCall.js";
@@ -894,6 +895,11 @@ describe("Testing examples", () => {
     );
 
     expect(topologyResult).toEqual(selfPeerId);
+  });
+
+  it("topology.aqua bug 257", async () => {
+    let result = await topologyBug257Call(peer2);
+    expect(result).toEqual(["host", "friend", "init"]);
   });
 
   it("foldJoin.aqua", async () => {

--- a/integration-tests/src/examples/topologyCall.ts
+++ b/integration-tests/src/examples/topologyCall.ts
@@ -6,6 +6,7 @@ import {
   topologyBug205,
   topologyBug394,
   topologyBug427,
+  topologyBug257,
 } from "../compiled/examples/topology.js";
 
 export async function topologyBug394Call(
@@ -65,4 +66,10 @@ export async function topologyCall(
       ttl: 10000,
     },
   );
+}
+
+export async function topologyBug257Call(
+  peer2: IFluenceClient,
+): Promise<string[]> {
+  return await topologyBug257(peer2.getPeerId(), peer2.getRelayPeerId());
 }

--- a/model/transform/src/main/scala/aqua/model/transform/cursor/ChainCursor.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/cursor/ChainCursor.scala
@@ -58,6 +58,9 @@ abstract class ChainCursor[C <: ChainCursor[C, T], T](make: NonEmptyList[ChainZi
 
   def toPrevSibling: Option[C] = tree.head.moveLeft.map(p => make(tree.copy(p)))
 
+  def nextSiblings: LazyList[C] =
+    LazyList.unfold(this)(_.toNextSibling.map(c => c -> c))
+
   def allToLeft: LazyList[C] =
     LazyList.unfold(this)(_.moveLeft.map(c => c -> c))
 

--- a/model/transform/src/main/scala/aqua/model/transform/topology/OpModelTreeCursor.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/OpModelTreeCursor.scala
@@ -29,6 +29,9 @@ case class OpModelTreeCursor(
   override lazy val toNextSibling: Option[OpModelTreeCursor] =
     super.toNextSibling.map(_.copy(cachedParent = cachedParent))
 
+  override lazy val nextSiblings: LazyList[OpModelTreeCursor] =
+    super.nextSiblings.map(_.copy(cachedParent = cachedParent))
+
   override def moveDown(focusOn: ChainZipper[OpModel.Tree]): OpModelTreeCursor =
     super.moveDown(focusOn).copy(cachedParent = Some(this))
 

--- a/model/transform/src/main/scala/aqua/model/transform/topology/PathFinder.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/PathFinder.scala
@@ -45,7 +45,9 @@ object PathFinder extends Logging {
     )
 
     // TODO: Is it always correct to do so?
-    toOn.peerId.fold(path)(p => path :+ p)
+    toOn.peerId
+      .filterNot(path.lastOption.contains)
+      .fold(path)(path :+ _)
   }
 
   private def findPath(

--- a/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
@@ -403,7 +403,6 @@ object Topology extends Logging {
       (if (rc.topology.pathAfter.value.nonEmpty) Console.YELLOW
        else "") + "PathAfter: " + Console.RESET + rc.topology.pathAfter.value
     )
-    println("Next Executes On: " + rc.topology.nextExecutesOn.value.show)
     println(Console.YELLOW + "     -     -     -     -     -" + Console.RESET)
   }
 

--- a/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
@@ -338,16 +338,6 @@ object Topology extends Logging {
 
       if (debug) printDebugInfo(rc, currI)
 
-      // rc.op match {
-      //   case OnModel(_, _, _) =>
-      //     printDebugInfo(rc, currI)
-      //   // case CallServiceModel(_, "fix", _) =>
-      //   //   printDebugInfo(rc, currI)
-      //   case XorModel =>
-      //     printDebugInfo(rc, currI)
-      //   case _ =>
-      // }
-
       val chainZipperEv = resolved.traverse(tree =>
         (
           rc.topology.pathBefore.map(through(_)),

--- a/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
@@ -42,8 +42,15 @@ trait After {
         (current.endsOn, current.relayOn).mapN(PathFinder.findPathEnforce)
       case ExitStrategy.Full =>
         (current.endsOn, current.afterOn, current.nextExecutesOn).mapN {
+          // This is an important optimization:
+          // If next execution forcing node is at the same path as
+          // `afterOn` of this node, then leave the last
+          // hop for it to handle
           case (ends, after, next) if next.forall(_ == after) =>
             PathFinder.findPath(ends, after)
+          // Otherwise, force return to relay.
+          // Returning to `after` would generate unnecessary hops,
+          // but is it always correct to return to relay here?
           case (ends, after, _) =>
             PathFinder.findPathEnforce(ends, after.toRelay)
         }

--- a/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
@@ -41,7 +41,7 @@ trait After {
       case ExitStrategy.ToRelay =>
         (current.endsOn, current.relayOn).mapN(PathFinder.findPathEnforce)
       case ExitStrategy.Full =>
-        (current.endsOn, current.afterOn).mapN(PathFinder.findPathEnforce)
+        (current.endsOn, current.afterOn).mapN(PathFinder.findPath)
     }
 
   // If exit is forced, make a path outside this node

--- a/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
@@ -41,7 +41,7 @@ trait After {
       case ExitStrategy.ToRelay =>
         (current.endsOn, current.relayOn).mapN(PathFinder.findPathEnforce)
       case ExitStrategy.Full =>
-        (current.endsOn, current.afterOn).mapN(PathFinder.findPath)
+        (current.endsOn, current.afterOn).mapN(PathFinder.findPathEnforce)
     }
 
   // If exit is forced, make a path outside this node

--- a/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/strategy/After.scala
@@ -41,7 +41,12 @@ trait After {
       case ExitStrategy.ToRelay =>
         (current.endsOn, current.relayOn).mapN(PathFinder.findPathEnforce)
       case ExitStrategy.Full =>
-        (current.endsOn, current.afterOn).mapN(PathFinder.findPath)
+        (current.endsOn, current.afterOn, current.nextExecutesOn).mapN {
+          case (ends, after, next) if next.forall(_ == after) =>
+            PathFinder.findPath(ends, after)
+          case (ends, after, _) =>
+            PathFinder.findPathEnforce(ends, after.toRelay)
+        }
     }
 
   // If exit is forced, make a path outside this node

--- a/model/transform/src/main/scala/aqua/model/transform/topology/strategy/XorBranch.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/strategy/XorBranch.scala
@@ -10,6 +10,7 @@ import cats.data.Chain
 import cats.syntax.functor.*
 import cats.instances.lazyList.*
 import cats.syntax.option.*
+import cats.syntax.apply.*
 
 // Parent == Xor
 object XorBranch extends Before with After {

--- a/model/transform/src/main/scala/aqua/model/transform/topology/strategy/XorBranch.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/strategy/XorBranch.scala
@@ -10,7 +10,6 @@ import cats.data.Chain
 import cats.syntax.functor.*
 import cats.instances.lazyList.*
 import cats.syntax.option.*
-import cats.syntax.apply.*
 
 // Parent == Xor
 object XorBranch extends Before with After {

--- a/model/transform/src/test/scala/aqua/model/transform/topology/TopologySpec.scala
+++ b/model/transform/src/test/scala/aqua/model/transform/topology/TopologySpec.scala
@@ -1235,7 +1235,7 @@ class TopologySpec extends AnyFlatSpec with Matchers {
               through(relay1),
               callRes(2, peer1),
               through(relay1),
-              through(relay)
+              through(relay) // TODO: LNG-259
             ),
             SeqRes.wrap(
               through(relay1),
@@ -1255,7 +1255,7 @@ class TopologySpec extends AnyFlatSpec with Matchers {
         else
           XorRes.wrap(
             SeqRes.wrap(
-              through(relay),
+              through(relay), // TODO: LNG-259
               through(relay2),
               callRes(3, peer2)
             ),


### PR DESCRIPTION
* Update topology: while computing `pathAfter`, find next `ForceExecModel` and generate exit to relay if its `pathOn` does not match our `afterOn` (it means that more hops will be done to reach it.
* Add unit and integration tests