### PR TITLE
fix(compiler): Return ability arrow [LNG-258]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -13,7 +13,7 @@ func create() -> TestAb:
         <- 42, 76
     <- TestAb(inner = InnerAb(arrow = arrow))
 
-func test() -> i8:
+func test() -> i8, i8:
     ababab <- create()
-    res <- ababab.inner.arrow()
-    <- res
+    res1, res2 <- ababab.inner.arrow()
+    <- res1, res2

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,26 +1,19 @@
-aqua M
+aqua A
 
-export getObj
+export test
 
-service OpNum("op"):
-    identity(n: u32) -> u32
+ability InnerAb:
+    arrow() -> i8, i8
 
-service OpStr("op"):
-    identity(n: string) -> string
+ability TestAb:
+    inner: InnerAb
 
-service OpArr("op"):
-    identity(arr: []string) -> []string
+func create() -> TestAb:
+    arrow = () -> i8, i8:
+        <- 42, 76
+    <- TestAb(inner = InnerAb(arrow = arrow))
 
-data InnerObj:
-    arr: []string
-    num: u32
-
-data SomeObj:
-    str: string
-    num: u64
-    inner: InnerObj
-
-func getObj() -> SomeObj:
-    b = SomeObj(str = OpStr.identity("some str"), num = 5, inner = InnerObj(arr = ["a", "b", "c"], num = 6))
-    c = b.copy(str = "new str", inner = b.inner.copy(num = 3))
-    <- c
+func test() -> i8:
+    ababab <- create()
+    res <- ababab.inner.arrow()
+    <- res

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -8,12 +8,27 @@ ability InnerAb:
 ability TestAb:
     inner: InnerAb
 
-func create() -> TestAb:
-    arrow = () -> i8, i8:
-        <- 42, 76
-    <- TestAb(inner = InnerAb(arrow = arrow))
+-- func create(a: i8, b: i8) -> TestAb:
+--     arrow = () -> i8, i8:
+--         <- a, b
+--     <- TestAb(inner = InnerAb(arrow = arrow))
+--
+-- func test() -> i8, i8, i8, i8, i8, i8:
+--     Ab <- create(1, 2)
+--     ab <- create(3, 4)
+--     AB <- create(5, 6)
+--     res1, res2 <- ab.inner.arrow()
+--     res3, res4 <- Ab.inner.arrow()
+--     res5, res6 <- AB.inner.arrow()
+--     <- res1, res2, res3, res4, res5, res6
 
-func test() -> i8, i8:
-    ababab <- create()
-    res1, res2 <- ababab.inner.arrow()
-    <- res1, res2
+func create(a: i8, b: i8) -> i8 -> i8, i8:
+    arrow = (c: i8) -> i8, i8:
+        <- a, b
+    <- arrow
+
+func test() -> i8, i8, i8, i8, i8, i8:
+    Ab <- create(1, 2)
+    ab <- create(3, 4)
+    AB <- create(5, 6)
+    <- res1, res2, res3, res4, res5, res6

--- a/integration-tests/aqua/examples/abilities.aqua
+++ b/integration-tests/aqua/examples/abilities.aqua
@@ -77,11 +77,13 @@ ability CCCC:
     arrow(x: i8) -> bool
     simple: SSS
 
-func checkAbCalls() -> bool, bool:
+func checkAbCalls() -> bool, bool, bool:
     closure = (x: i8) -> bool:
         <- x > 20
 
     MySSS = SSS(arrow = closure)
     MyCCCC = CCCC(simple = MySSS, arrow = MySSS.arrow)
+    res1 <- MySSS.arrow(42)
+    res2 = MyCCCC.arrow(12)
 
-    <- MySSS.arrow(42), MyCCCC.arrow(12)
+    <- res1, res2, MySSS.arrow(50)

--- a/integration-tests/aqua/examples/abilities.aqua
+++ b/integration-tests/aqua/examples/abilities.aqua
@@ -2,7 +2,7 @@ aqua Main
 
 use DECLARE_CONST, decl_bar from "imports_exports/declare.aqua" as Declare
 
-export handleAb, SomeService, bug214, checkAbCalls
+export handleAb, SomeService, bug214, checkAbCalls, bugLNG258_1, bugLNG258_2, bugLNG258_3
 
 service SomeService("wed"):
   getStr(s: string) -> string
@@ -87,3 +87,31 @@ func checkAbCalls() -> bool, bool, bool:
     res2 = MyCCCC.arrow(12)
 
     <- res1, res2, MySSS.arrow(50)
+
+ability InnerAb:
+    arrow() -> i8, i8
+
+ability TestAb:
+    inner: InnerAb
+
+func create(a: i8, b: i8) -> TestAb:
+    arrow = () -> i8, i8:
+        <- a, b
+    <- TestAb(inner = InnerAb(arrow = arrow))
+
+func bugLNG258_1() -> i8, i8:
+    ab <- create(1, 2)
+    res1, res2 <- ab.inner.arrow()
+    <- res1, res2
+
+func bugLNG258_2() -> i8, i8:
+    AB <- create(3, 4)
+    res1, res2 <- AB.inner.arrow()
+    <- res1, res2
+
+func bugLNG258_3() -> i8, i8:
+    aB <- create(5, 6)
+    res1, res2 <- aB.inner.arrow()
+    <- res1, res2
+
+

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -550,7 +550,7 @@ describe("Testing examples", () => {
 
   it("ability.aqua ability calls", async () => {
     let result = await checkAbCallsCall();
-    expect(result).toStrictEqual([true, false]);
+    expect(result).toStrictEqual([true, false, true]);
   });
 
   it("functors.aqua LNG-119 bug", async () => {

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -33,7 +33,7 @@ import {
 import {
   abilityCall,
   complexAbilityCall,
-  checkAbCallsCall,
+  checkAbCallsCall, bugLNG258Call1, bugLNG258Call2, bugLNG258Call3,
 } from "../examples/abilityCall.js";
 import {
   nilLengthCall,
@@ -551,6 +551,17 @@ describe("Testing examples", () => {
   it("ability.aqua ability calls", async () => {
     let result = await checkAbCallsCall();
     expect(result).toStrictEqual([true, false, true]);
+  });
+
+  it("ability.aqua bug LNG-258", async () => {
+    let result1 = await bugLNG258Call1();
+    expect(result1).toStrictEqual([1, 2]);
+
+    let result2 = await bugLNG258Call2();
+    expect(result2).toStrictEqual([3, 4]);
+
+    let result3 = await bugLNG258Call3();
+    expect(result3).toStrictEqual([5, 6]);
   });
 
   it("functors.aqua LNG-119 bug", async () => {

--- a/integration-tests/src/examples/abilityCall.ts
+++ b/integration-tests/src/examples/abilityCall.ts
@@ -3,6 +3,9 @@ import {
   registerSomeService,
   bug214,
   checkAbCalls,
+  bugLNG258_1,
+  bugLNG258_2,
+  bugLNG258_3,
 } from "../compiled/examples/abilities";
 
 export async function abilityCall(): Promise<[string, string, string, number]> {
@@ -21,4 +24,16 @@ export async function complexAbilityCall(): Promise<[boolean, boolean]> {
 
 export async function checkAbCallsCall(): Promise<[boolean, boolean, boolean]> {
   return await checkAbCalls();
+}
+
+export async function bugLNG258Call1(): Promise<[number, number]> {
+  return await bugLNG258_1();
+}
+
+export async function bugLNG258Call2(): Promise<[number, number]> {
+  return await bugLNG258_2();
+}
+
+export async function bugLNG258Call3(): Promise<[number, number]> {
+  return await bugLNG258_3();
 }

--- a/integration-tests/src/examples/abilityCall.ts
+++ b/integration-tests/src/examples/abilityCall.ts
@@ -19,6 +19,6 @@ export async function complexAbilityCall(): Promise<[boolean, boolean]> {
   return await bug214();
 }
 
-export async function checkAbCallsCall(): Promise<[boolean, boolean]> {
+export async function checkAbCallsCall(): Promise<[boolean, boolean, boolean]> {
   return await checkAbCalls();
 }

--- a/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
@@ -86,7 +86,7 @@ object ArrowInliner extends Logging {
     call: CallModel,
     outsideDeclaredStreams: Set[String]
   ): State[S, InlineResult] = for {
-    callableFuncBodyNoTopology <- TagInliner.handleTree(fn.body, fn.funcName)
+    callableFuncBodyNoTopology <- TagInliner.handleTree(fn.body)
     callableFuncBody =
       fn.capturedTopology
         .fold(SeqModel)(ApplyTopologyModel.apply)

--- a/model/inline/src/main/scala/aqua/model/inline/Inline.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/Inline.scala
@@ -30,6 +30,12 @@ private[inline] case class Inline(
       case Some(tree) => copy(predo = predo :+ tree)
     }
 
+  def prepend(tree: Option[OpModel.Tree]): Inline =
+    tree match {
+      case None => this
+      case Some(tree) => copy(predo = tree +: predo)
+    }
+
   def desugar: Inline = {
     val desugaredPredo = predo match {
       case Chain.nil | _ ==: Chain.nil => predo

--- a/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
@@ -324,6 +324,25 @@ object TagInliner extends Logging {
             )
         }
 
+      case CallArrowRawTag(
+            exportTo,
+            // the name of VarModel was already converted to abilities full name
+            ApplyPropertyRaw(VarModel(n, _, _), IntoArrowRaw(name, at, args))
+          ) =>
+        CallArrowRawInliner.unfold(CallArrowRaw.ability(n, name, at, args), exportTo).flatMap {
+          case (_, inline) =>
+            RawValueInliner
+              .inlineToTree(inline)
+              .map(tree =>
+                TagInlined.Empty(
+                  prefix = SeqModel.wrap(tree).some
+                )
+              )
+        }
+
+      case CallArrowRawTag(_, value) =>
+        internalError(s"Cannot inline 'CallArrowRawTag' with value '$value'")
+
       case AssignmentTag(value, assignTo) =>
         for {
           modelAndPrefix <- value match {

--- a/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
@@ -328,7 +328,7 @@ object TagInliner extends Logging {
             CallArrowRawInliner.unfold(CallArrowRaw.ability(n, name, at, args), exportTo).flatMap {
               case (_, inline) =>
                 RawValueInliner
-                  .inlineToTree(inline.copy(predo = Chain.fromOption(prevInline) ++ inline.predo))
+                  .inlineToTree(inline.prepend(prevInline))
                   .map(tree =>
                     TagInlined.Empty(
                       prefix = SeqModel.wrap(tree).some

--- a/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
@@ -1,28 +1,23 @@
 package aqua.model.inline
 
 import aqua.errors.Errors.internalError
-import aqua.model.inline.state.{Arrows, Exports, Mangler}
 import aqua.model.*
 import aqua.model.inline.RawValueInliner.collectionToModel
 import aqua.model.inline.raw.{CallArrowRawInliner, CallServiceRawInliner}
-import aqua.raw.value.ApplyBinaryOpRaw.Op as BinOp
+import aqua.model.inline.state.{Arrows, Exports, Mangler}
+import aqua.model.inline.tag.IfTagInliner
 import aqua.raw.ops.*
 import aqua.raw.value.*
-import aqua.types.{BoxType, CanonStreamType, DataType, StreamType}
-import aqua.model.inline.Inline.parDesugarPrefixOpt
-import aqua.model.inline.tag.IfTagInliner
-
-import cats.syntax.traverse.*
+import aqua.types.{BoxType, CanonStreamType, StreamType}
+import cats.data.{Chain, State, StateT}
+import cats.instances.list.*
 import cats.syntax.applicative.*
-import cats.syntax.flatMap.*
 import cats.syntax.apply.*
+import cats.syntax.bifunctor.*
 import cats.syntax.functor.*
 import cats.syntax.option.*
-import cats.instances.list.*
-import cats.data.{Chain, State, StateT}
-import cats.syntax.show.*
-import cats.syntax.bifunctor.*
-import scribe.{log, Logging}
+import cats.syntax.traverse.*
+import scribe.Logging
 
 /**
  * [[TagInliner]] prepares a [[RawTag]] for futher processing by converting [[ValueRaw]]s into [[ValueModel]]s.
@@ -35,8 +30,7 @@ import scribe.{log, Logging}
  */
 object TagInliner extends Logging {
 
-  import RawValueInliner.{callToModel, valueListToModel, valueToModel}
-
+  import RawValueInliner.{valueListToModel, valueToModel}
   import aqua.model.inline.Inline.parDesugarPrefix
 
   /**
@@ -178,8 +172,7 @@ object TagInliner extends Logging {
    * @return Model (if any), and prefix (if any)
    */
   def tagToModel[S: Mangler: Arrows: Exports](
-    tag: RawTag,
-    treeFunctionName: String
+    tag: RawTag
   ): State[S, TagInlined] =
     tag match {
       case OnTag(peerId, via, strategy) =>
@@ -326,20 +319,25 @@ object TagInliner extends Logging {
 
       case CallArrowRawTag(
             exportTo,
-            // the name of VarModel was already converted to abilities full name
-            ApplyPropertyRaw(VarModel(n, _, _), IntoArrowRaw(name, at, args))
+            ApplyPropertyRaw(vr, IntoArrowRaw(name, at, args))
           ) =>
-        CallArrowRawInliner.unfold(CallArrowRaw.ability(n, name, at, args), exportTo).flatMap {
-          case (_, inline) =>
-            RawValueInliner
-              .inlineToTree(inline)
-              .map(tree =>
-                TagInlined.Empty(
-                  prefix = SeqModel.wrap(tree).some
-                )
-              )
-        }
+        RawValueInliner.valueToModel(vr).flatMap {
+          // the name of VarModel was already converted to abilities full name
+          case (VarModel(n, _, _), prevInline) =>
+            CallArrowRawInliner.unfold(CallArrowRaw.ability(n, name, at, args), exportTo).flatMap {
+              case (_, inline) =>
+                RawValueInliner
+                  .inlineToTree(inline.copy(predo = Chain.fromOption(prevInline) ++ inline.predo))
+                  .map(tree =>
+                    TagInlined.Empty(
+                      prefix = SeqModel.wrap(tree).some
+                    )
+                  )
+            }
+          case _ =>
+            internalError(s"Unexpected. 'IntoArrowRaw' can be only used on variables")
 
+        }
       case CallArrowRawTag(_, value) =>
         internalError(s"Cannot inline 'CallArrowRawTag' with value '$value'")
 
@@ -448,8 +446,7 @@ object TagInliner extends Logging {
     } yield headInlined.build(children)
 
   def handleTree[S: Exports: Mangler: Arrows](
-    tree: RawTag.Tree,
-    treeFunctionName: String
+    tree: RawTag.Tree
   ): State[S, OpModel.Tree] =
-    traverseS(tree, tagToModel(_, treeFunctionName))
+    traverseS(tree, tagToModel(_))
 }

--- a/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
@@ -9,6 +9,7 @@ import aqua.model.inline.tag.IfTagInliner
 import aqua.raw.ops.*
 import aqua.raw.value.*
 import aqua.types.{BoxType, CanonStreamType, StreamType}
+
 import cats.data.{Chain, State, StateT}
 import cats.instances.list.*
 import cats.syntax.applicative.*

--- a/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
@@ -17,7 +17,7 @@ object CallArrowRawInliner extends RawInliner[CallArrowRaw] with Logging {
   private[inline] def unfold[S: Mangler: Exports: Arrows](
     value: CallArrowRaw,
     exportTo: List[Call.Export]
-  ): State[S, (List[ValueModel], Inline)] = Exports[S].exports.flatMap { exports =>
+  ): State[S, (List[ValueModel], Inline)] = {
     logger.trace(s"${exportTo.mkString(" ")} $value")
 
     val call = Call(value.arguments, exportTo)

--- a/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
@@ -7,7 +7,6 @@ import aqua.model.inline.state.{Arrows, Exports, Mangler}
 import aqua.model.inline.{ArrowInliner, Inline, RawValueInliner}
 import aqua.raw.ops.Call
 import aqua.raw.value.CallArrowRaw
-import aqua.types.AbilityType
 
 import cats.data.{Chain, State}
 import cats.syntax.traverse.*

--- a/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
@@ -29,16 +29,7 @@ object CallArrowRawInliner extends RawInliner[CallArrowRaw] with Logging {
     val funcName = value.ability.fold(value.name)(_ + "." + value.name)
     logger.trace(s"            $funcName")
 
-    value.abValue.map { v =>
-      // inline var to get the left side of the ability call's name
-      RawValueInliner.unfold(v).flatMap {
-        case (VarModel(name, _, _), _) =>
-          resolveArrow(AbilityType.fullName(name, funcName), call)
-        case l =>
-          internalError(s"Ability cannot be a literal ($l)")
-      }
-    }.getOrElse(resolveArrow(funcName, call))
-
+    resolveArrow(funcName, call)
   }
 
   private def resolveFuncArrow[S: Mangler: Exports: Arrows](

--- a/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
@@ -31,7 +31,7 @@ object CallArrowRawInliner extends RawInliner[CallArrowRaw] with Logging {
 
     value.abValue.map { v =>
       // inline var to get the left side of the ability call's name
-      RawValueInliner.unfold(v, false).flatMap {
+      RawValueInliner.unfold(v).flatMap {
         case (VarModel(name, _, _), _) =>
           resolveArrow(AbilityType.fullName(name, funcName), call)
         case l =>

--- a/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/raw/CallArrowRawInliner.scala
@@ -8,6 +8,7 @@ import aqua.model.inline.{ArrowInliner, Inline, RawValueInliner}
 import aqua.raw.ops.Call
 import aqua.raw.value.CallArrowRaw
 import aqua.types.AbilityType
+
 import cats.data.{Chain, State}
 import cats.syntax.traverse.*
 import scribe.Logging

--- a/model/inline/src/test/scala/aqua/model/inline/TagInlinerSpec.scala
+++ b/model/inline/src/test/scala/aqua/model/inline/TagInlinerSpec.scala
@@ -18,8 +18,7 @@ class TagInlinerSpec extends AnyFlatSpec with Matchers with Inside {
 
     val (state, inlined) = TagInliner
       .tagToModel[InliningState](
-        CanonicalizeTag(ValueRaw.Nil, Call.Export(canonTo, StreamType(ScalarType.string))),
-        ""
+        CanonicalizeTag(ValueRaw.Nil, Call.Export(canonTo, StreamType(ScalarType.string)))
       )
       .run(InliningState())
       .value
@@ -39,8 +38,7 @@ class TagInlinerSpec extends AnyFlatSpec with Matchers with Inside {
 
     val (state, inlined) = TagInliner
       .tagToModel[InliningState](
-        FlattenTag(ValueRaw.Nil, canonTo),
-        ""
+        FlattenTag(ValueRaw.Nil, canonTo)
       )
       .run(InliningState())
       .value

--- a/model/raw/src/main/scala/aqua/raw/value/PropertyRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/PropertyRaw.scala
@@ -1,6 +1,6 @@
 package aqua.raw.value
 
-import aqua.types.{StructType, Type}
+import aqua.types.{ArrowType, NilType, StructType, Type}
 import cats.data.NonEmptyMap
 
 sealed trait PropertyRaw {
@@ -22,10 +22,10 @@ case class IntoFieldRaw(name: String, `type`: Type) extends PropertyRaw {
   override def varNames: Set[String] = Set.empty
 }
 
-case class IntoArrowRaw(name: String, arrowType: Type, arguments: List[ValueRaw])
+case class IntoArrowRaw(name: String, arrowType: ArrowType, arguments: List[ValueRaw])
     extends PropertyRaw {
 
-  override def `type`: Type = arrowType
+  override def `type`: Type = arrowType.codomain.uncons.map(_._1).getOrElse(NilType)
 
   override def map(f: ValueRaw => ValueRaw): PropertyRaw =
     copy(arguments = arguments.map(f))

--- a/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
@@ -316,7 +316,9 @@ case class CallArrowRaw(
   ability: Option[String],
   name: String,
   arguments: List[ValueRaw],
-  baseType: ArrowType
+  baseType: ArrowType,
+  // left part of an ability (what calls arrow)
+  abValue: Option[ValueRaw] = None
 ) extends ValueRaw {
   override def `type`: Type = baseType.codomain.headOption.getOrElse(baseType)
 

--- a/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
@@ -317,8 +317,6 @@ case class CallArrowRaw(
   name: String,
   arguments: List[ValueRaw],
   baseType: ArrowType,
-  // left part of an ability (what calls arrow)
-  abValue: Option[ValueRaw] = None
 ) extends ValueRaw {
   override def `type`: Type = baseType.codomain.headOption.getOrElse(baseType)
 

--- a/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
@@ -5,7 +5,6 @@ import aqua.types.*
 import cats.data.{Chain, NonEmptyList, NonEmptyMap}
 import cats.Eq
 import cats.syntax.option.*
-import scribe.Logging
 
 sealed trait ValueRaw {
 

--- a/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
@@ -315,7 +315,7 @@ case class CallArrowRaw(
   ability: Option[String],
   name: String,
   arguments: List[ValueRaw],
-  baseType: ArrowType,
+  baseType: ArrowType
 ) extends ValueRaw {
   override def `type`: Type = baseType.codomain.headOption.getOrElse(baseType)
 

--- a/parser/src/main/scala/aqua/parser/expr/func/CallArrowExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/func/CallArrowExpr.scala
@@ -27,7 +27,7 @@ case class CallArrowExpr[F[_]](
 object CallArrowExpr extends Expr.Leaf {
 
   override val p: P[CallArrowExpr[Span.S]] = {
-    val variables: P0[Option[NonEmptyList[Name[Span.S]]]] = (comma(Name.p) <* ` <- `).backtrack.?
+    val variables: P0[Option[NonEmptyList[Name[Span.S]]]] = (comma(Name.variable) <* ` <- `).backtrack.?
 
     // TODO:    Restrict to function call only
     //          or allow any expression?

--- a/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
@@ -42,7 +42,7 @@ class CallArrowSem[S[_]](val expr: CallArrowExpr[S]) extends AnyVal {
     V: ValuesAlgebra[S, Alg]
   ): Alg[Option[FuncOp]] = for {
     // TODO: Accept other expressions
-    callArrowRaw <- V.valueToCallArrowRaw(expr.callArrow)
+    callArrowRaw <- V.valueToCall(expr.callArrow)
     tag <- callArrowRaw.traverse { case (raw, at) =>
       getExports(at.codomain).map(CallArrowRawTag(_, raw)) <*
         T.checkArrowCallResults(callArrow, at, variables)

--- a/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
@@ -43,10 +43,10 @@ class CallArrowSem[S[_]](val expr: CallArrowExpr[S]) extends AnyVal {
   ): Alg[Option[FuncOp]] = for {
     // TODO: Accept other expressions
     callArrowRaw <- V.valueToCallArrowRaw(expr.callArrow)
-    tag <- callArrowRaw.traverse(car =>
-      getExports(car.baseType.codomain).map(CallArrowRawTag(_, car)) <*
-        T.checkArrowCallResults(callArrow, car.baseType, variables)
-    )
+    tag <- callArrowRaw.traverse { case (raw, at) =>
+      getExports(at.codomain).map(CallArrowRawTag(_, raw)) <*
+        T.checkArrowCallResults(callArrow, at, variables)
+    }
   } yield tag.map(_.funcOpLeaf)
 
   def program[Alg[_]: Monad](using

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ClosureSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ClosureSem.scala
@@ -29,7 +29,7 @@ class ClosureSem[S[_]](val expr: ClosureExpr[S]) extends AnyVal {
           isRoot = false
         ) as ClosureTag(FuncRaw(expr.name.value, arrow), expr.detach.isDefined).funcOpLeaf
 
-      case m =>
+      case _ =>
         Raw.error("Closure must continue with an arrow definition").pure[Alg]
     }
 

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -293,7 +293,7 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
         }
     }
 
-  def valueToCallArrowRaw(v: ValueToken[S]): Alg[Option[(ValueRaw, ArrowType)]] =
+  def valueToCall(v: ValueToken[S]): Alg[Option[(ValueRaw, ArrowType)]] =
     valueToRaw(v).flatMap(
       _.flatTraverse {
         case ca: CallArrowRaw => (ca, ca.baseType).some.pure[Alg]

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -298,9 +298,7 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
       _.flatTraverse {
         case ca: CallArrowRaw => ca.some.pure[Alg]
         case ApplyPropertyRaw(value, IntoArrowRaw(name, arrowType, arguments)) =>
-          // IntoArrow can be only last in a properties chain
-          // Store left part of the value and properties into CallArrowRaw to inline it later
-          CallArrowRaw(None, name, arguments, arrowType, Some(value)).some.pure[Alg]
+          CallArrowRaw(None, name, arguments, arrowType).some.pure[Alg]
         // TODO: better error message (`raw` formatting)
         case raw => report.error(v, s"Expected arrow call, got $raw").as(none)
       }

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -297,6 +297,10 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
     valueToRaw(v).flatMap(
       _.flatTraverse {
         case ca: CallArrowRaw => ca.some.pure[Alg]
+        case ApplyPropertyRaw(value, IntoArrowRaw(name, arrowType, arguments)) =>
+          // IntoArrow can be only last in a properties chain
+          // Store left part of the value and properties into CallArrowRaw to inline it later
+          CallArrowRaw(None, name, arguments, arrowType, Some(value)).some.pure[Alg]
         // TODO: better error message (`raw` formatting)
         case raw => report.error(v, s"Expected arrow call, got $raw").as(none)
       }

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -221,11 +221,10 @@ class TypesInterpreter[S[_], X](using
               .pointFieldLocation(name, op.name.value, op)
               .as(Some(IntoArrowRaw(op.name.value, at, arguments)))
           case _ =>
-            // Unexpected
             report
               .error(
                 op,
-                s"`${op.name.value}` must be an arrow."
+                s"Unexpected. `${op.name.value}` must be an arrow."
               )
               .as(None)
         }

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -215,15 +215,19 @@ class TypesInterpreter[S[_], X](using
               s"Arrow `${op.name.value}` not found in type `$name`, available: ${fieldsAndArrows.toNel.toList.map(_._1).mkString(", ")}"
             )
             .as(None)
-        ) { t =>
-          val resolvedType = t match {
-            // TODO: is it a correct way to resolve `IntoArrow` type?
-            case ArrowType(_, codomain) => codomain.uncons.map(_._1).getOrElse(t)
-            case _ => t
-          }
-          locations
-            .pointFieldLocation(name, op.name.value, op)
-            .as(Some(IntoArrowRaw(op.name.value, resolvedType, arguments)))
+        ) {
+          case at@ArrowType(_, _) =>
+            locations
+              .pointFieldLocation(name, op.name.value, op)
+              .as(Some(IntoArrowRaw(op.name.value, at, arguments)))
+          case _ =>
+            // Unexpected
+            report
+              .error(
+                op,
+                s"`${op.name.value}` must be an arrow."
+              )
+              .as(None)
         }
       case t =>
         t.properties


### PR DESCRIPTION
## Description
After this PR functions in abilities can be called with `<-` symbol, as common functions.

```
func create() -> TestAb:
    arrow = () -> i8, i8:
        <- 42, 76
    <- TestAb(inner = InnerAb(arrow = arrow))

func test() -> i8, i8:
    ababab <- create()
    res1, res2 <- ababab.inner.arrow()
    <- res1, res2
```

## Implementation Details
Handle `ApplyPropertyRaw` with `IntoArrowRaw` for `CallArrowRawTag`

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

