### PR TITLE
fix(compiler): Multiple closures in one function [LNG-262]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -2,33 +2,12 @@ aqua A
 
 export test
 
-ability InnerAb:
-    arrow() -> i8, i8
+func create(a: i8) -> -> i8:
+    closureArrow = () -> i8:
+        <- a
+    <- closureArrow
 
-ability TestAb:
-    inner: InnerAb
-
--- func create(a: i8, b: i8) -> TestAb:
---     arrow = () -> i8, i8:
---         <- a, b
---     <- TestAb(inner = InnerAb(arrow = arrow))
---
--- func test() -> i8, i8, i8, i8, i8, i8:
---     Ab <- create(1, 2)
---     ab <- create(3, 4)
---     AB <- create(5, 6)
---     res1, res2 <- ab.inner.arrow()
---     res3, res4 <- Ab.inner.arrow()
---     res5, res6 <- AB.inner.arrow()
---     <- res1, res2, res3, res4, res5, res6
-
-func create(a: i8, b: i8) -> i8 -> i8, i8:
-    arrow = (c: i8) -> i8, i8:
-        <- a, b
-    <- arrow
-
-func test() -> i8, i8, i8, i8, i8, i8:
-    Ab <- create(1, 2)
-    ab <- create(3, 4)
-    AB <- create(5, 6)
-    <- res1, res2, res3, res4, res5, res6
+func test() -> i8, i8:
+    arr1 <- create(1)
+    arr2 <- create(2)
+    <- arr1(), arr2()

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -2,15 +2,15 @@ aqua A
 
 export bugLNG260
 
--- func create(a: i8) -> -> i8:
---     closureArrow = () -> i8:
---         <- a
---     <- closureArrow
---
--- func test() -> i8, i8:
---     arr1 <- create(1)
---     arr2 <- create(2)
---     <- arr1(), arr2()
+func create(a: i8) -> -> i8:
+    closureArrow = () -> i8:
+        <- a
+    <- closureArrow
+
+func test() -> i8, i8:
+    arr1 <- create(1)
+    arr2 <- create(2)
+    <- arr1(), arr2()
 
 func cmp(a: i32, b: i32, pred: i8 -> bool) -> bool:
   result: ?bool

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,13 +1,35 @@
 aqua A
 
-export test
+export bugLNG260
 
-func create(a: i8) -> -> i8:
-    closureArrow = () -> i8:
-        <- a
-    <- closureArrow
+-- func create(a: i8) -> -> i8:
+--     closureArrow = () -> i8:
+--         <- a
+--     <- closureArrow
+--
+-- func test() -> i8, i8:
+--     arr1 <- create(1)
+--     arr2 <- create(2)
+--     <- arr1(), arr2()
 
-func test() -> i8, i8:
-    arr1 <- create(1)
-    arr2 <- create(2)
-    <- arr1(), arr2()
+func cmp(a: i32, b: i32, pred: i8 -> bool) -> bool:
+  result: ?bool
+
+  if a < b:
+    result <- pred(-1)
+  else:
+    if a == b:
+      result <- pred(0)
+    else:
+      result <- pred(1)
+
+  <- result!
+
+func gt(a: i32, b: i32) -> bool:
+  pred = (ord: i8) -> bool:
+        <- ord > 0
+
+  <- cmp(a, b, pred)
+
+func bugLNG260(a: i32, b: i32) -> bool:
+  <- gt(a, b)

--- a/integration-tests/aqua/examples/abilities.aqua
+++ b/integration-tests/aqua/examples/abilities.aqua
@@ -2,7 +2,7 @@ aqua Main
 
 use DECLARE_CONST, decl_bar from "imports_exports/declare.aqua" as Declare
 
-export handleAb, SomeService, bug214, checkAbCalls, bugLNG258_1, bugLNG258_2, bugLNG258_3
+export handleAb, SomeService, bug214, checkAbCalls, bugLNG258_1, bugLNG258_2, bugLNG258_3, multipleAbilityWithClosure
 
 service SomeService("wed"):
   getStr(s: string) -> string
@@ -113,5 +113,19 @@ func bugLNG258_3() -> i8, i8:
     aB <- create(5, 6)
     res1, res2 <- aB.inner.arrow()
     <- res1, res2
+
+ability TestAb:
+    arrow: -> i8
+
+func create(a: i8) -> TestAb:
+    closureArrow = () -> i8:
+        <- a
+    ab = TestAb(arrow = closureArrow)
+    <- ab
+
+func multipleAbilityWithClosure() -> i8, i8:
+    ab <- create(1)
+    ab2 <- create(2)
+    <- ab.arrow(), ab2.arrow()
 
 

--- a/integration-tests/aqua/examples/abilities.aqua
+++ b/integration-tests/aqua/examples/abilities.aqua
@@ -117,15 +117,15 @@ func bugLNG258_3() -> i8, i8:
 ability TestAbWithClosure:
     arrow: -> i8
 
-func create(a: i8) -> TestAbWithClosure:
+func createAb(a: i8) -> TestAbWithClosure:
     closureArrow = () -> i8:
         <- a
     ab = TestAbWithClosure(arrow = closureArrow)
     <- ab
 
 func multipleAbilityWithClosure() -> i8, i8:
-    ab <- create(1)
-    ab2 <- create(2)
+    ab <- createAb(1)
+    ab2 <- createAb(2)
     <- ab.arrow(), ab2.arrow()
 
 

--- a/integration-tests/aqua/examples/abilities.aqua
+++ b/integration-tests/aqua/examples/abilities.aqua
@@ -114,13 +114,13 @@ func bugLNG258_3() -> i8, i8:
     res1, res2 <- aB.inner.arrow()
     <- res1, res2
 
-ability TestAb:
+ability TestAbWithClosure:
     arrow: -> i8
 
-func create(a: i8) -> TestAb:
+func create(a: i8) -> TestAbWithClosure:
     closureArrow = () -> i8:
         <- a
-    ab = TestAb(arrow = closureArrow)
+    ab = TestAbWithClosure(arrow = closureArrow)
     <- ab
 
 func multipleAbilityWithClosure() -> i8, i8:

--- a/integration-tests/aqua/examples/closures.aqua
+++ b/integration-tests/aqua/examples/closures.aqua
@@ -2,7 +2,7 @@ module Closure declares *
 
 import "@fluencelabs/aqua-lib/builtin.aqua"
 
-export LocalSrv, closureIn, closureOut, closureBig, closureOut2, lng58Bug
+export LocalSrv, closureIn, closureOut, closureBig, closureOut2, lng58Bug, multipleClosuresBugLNG262
 
 service MyOp("op"):
   identity(s: string) -> string
@@ -71,3 +71,13 @@ func lng58Bug() -> string:
   waiting()
 
   <- status!
+
+func create(a: i8) -> -> i8:
+    closureArrow = () -> i8:
+        <- a
+    <- closureArrow
+
+func multipleClosuresBugLNG262() -> i8, i8:
+    arr1 <- create(1)
+    arr2 <- create(2)
+    <- arr1(), arr2()

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -33,7 +33,7 @@ import {
 import {
   abilityCall,
   complexAbilityCall,
-  checkAbCallsCall, bugLNG258Call1, bugLNG258Call2, bugLNG258Call3,
+  checkAbCallsCall, bugLNG258Call1, bugLNG258Call2, bugLNG258Call3, multipleAbilityWithClosureCall,
 } from "../examples/abilityCall.js";
 import {
   nilLengthCall,
@@ -533,7 +533,7 @@ describe("Testing examples", () => {
     });
   });
 
-  it("ability.aqua", async () => {
+  it("abilities.aqua", async () => {
     let result = await abilityCall();
     expect(result).toStrictEqual([
       "declare_const123",
@@ -543,17 +543,17 @@ describe("Testing examples", () => {
     ]);
   });
 
-  it("ability.aqua complex", async () => {
+  it("abilities.aqua complex", async () => {
     let result = await complexAbilityCall();
     expect(result).toStrictEqual([false, true]);
   });
 
-  it("ability.aqua ability calls", async () => {
+  it("abilities.aqua ability calls", async () => {
     let result = await checkAbCallsCall();
     expect(result).toStrictEqual([true, false, true]);
   });
 
-  it("ability.aqua bug LNG-258", async () => {
+  it("abilities.aqua bug LNG-258", async () => {
     let result1 = await bugLNG258Call1();
     expect(result1).toStrictEqual([1, 2]);
 
@@ -562,6 +562,11 @@ describe("Testing examples", () => {
 
     let result3 = await bugLNG258Call3();
     expect(result3).toStrictEqual([5, 6]);
+  });
+
+  it("abilities.aqua multiple abilities with closures", async () => {
+    let result1 = await multipleAbilityWithClosureCall();
+    expect(result1).toStrictEqual([1, 2]);
   });
 
   it("functors.aqua LNG-119 bug", async () => {

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -104,7 +104,7 @@ import { multiReturnCall } from "../examples/multiReturnCall.js";
 import { declareCall } from "../examples/declareCall.js";
 import { genOptions, genOptionsEmptyString } from "../examples/optionsCall.js";
 import { lng193BugCall } from "../examples/closureReturnRename.js";
-import { closuresCall } from "../examples/closures.js";
+import {closuresCall, multipleClosuresLNG262BugCall} from "../examples/closures.js";
 import { closureArrowCaptureCall } from "../examples/closureArrowCapture.js";
 import {
   bugLNG63_2Call,
@@ -948,6 +948,11 @@ describe("Testing examples", () => {
     let res2 = ["in", config.externalAddressesRelay2[0]];
     expect(closuresResult).toEqual(["in", res1, res1, res2]);
   }, 20000);
+
+  it("closures.aqua bug LNG-262", async () => {
+    let result = await multipleClosuresLNG262BugCall();
+    expect(result).toEqual([1, 2]);
+  });
 
   it("closureArrowCapture.aqua", async () => {
     let result = await closureArrowCaptureCall("input");

--- a/integration-tests/src/examples/abilityCall.ts
+++ b/integration-tests/src/examples/abilityCall.ts
@@ -6,6 +6,7 @@ import {
   bugLNG258_1,
   bugLNG258_2,
   bugLNG258_3,
+  multipleAbilityWithClosure
 } from "../compiled/examples/abilities";
 
 export async function abilityCall(): Promise<[string, string, string, number]> {
@@ -36,4 +37,8 @@ export async function bugLNG258Call2(): Promise<[number, number]> {
 
 export async function bugLNG258Call3(): Promise<[number, number]> {
   return await bugLNG258_3();
+}
+
+export async function multipleAbilityWithClosureCall(): Promise<[number, number]> {
+  return await multipleAbilityWithClosure()
 }

--- a/integration-tests/src/examples/closures.ts
+++ b/integration-tests/src/examples/closures.ts
@@ -5,6 +5,7 @@ import {
   registerLocalSrv,
   closureOut2,
   lng58Bug,
+  multipleClosuresBugLNG262
 } from "../compiled/examples/closures.js";
 import { config } from "../config.js";
 
@@ -31,4 +32,8 @@ export async function closuresCall(): Promise<
 
 export async function lng58CBugCall(): Promise<string> {
   return lng58Bug();
+}
+
+export async function multipleClosuresLNG262BugCall(): Promise<[number, number]> {
+  return multipleClosuresBugLNG262();
 }

--- a/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
@@ -340,7 +340,7 @@ object ArrowInliner extends Logging {
 
     _ <- Arrows[S].resolved(arrowsResolved)
     _ <- Exports[S].resolved(exportsResolved)
-  } yield fn.copy(body = tree, ret = ret, capturedValues = capturedValues.renamed)
+  } yield fn.copy(body = tree, ret = ret)
 
   private[inline] def callArrowRet[S: Exports: Arrows: Mangler](
     arrow: FuncArrow,

--- a/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
@@ -60,7 +60,7 @@ object ArrowInliner extends Logging {
               ) if !outsideStreamNames.contains(n) =>
             resDesugar.toList -> res
           case (
-                cexp @ CallModel.Export(exp, st @ StreamType(_)),
+                cexp @ CallModel.Export(_, StreamType(_)),
                 (res, resDesugar)
               ) =>
             // pass nested function results to a stream
@@ -340,7 +340,7 @@ object ArrowInliner extends Logging {
 
     _ <- Arrows[S].resolved(arrowsResolved)
     _ <- Exports[S].resolved(exportsResolved)
-  } yield fn.copy(body = tree, ret = ret)
+  } yield fn.copy(body = tree, ret = ret, capturedValues = capturedValues.renamed)
 
   private[inline] def callArrowRet[S: Exports: Arrows: Mangler](
     arrow: FuncArrow,

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -301,6 +301,7 @@ case class ClosureTag(
     copy(
       func.copy(arrow =
         func.arrow.copy(
+          ret = func.arrow.ret.map(_.map(f)),
           body = func.arrow.body.map(_.mapValues(f))
         )
       )

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -290,13 +290,17 @@ case class ClosureTag(
   override def usesVarNames: Set[String] = Set.empty
 
   override def renameExports(map: Map[String, String]): RawTag =
-    copy(func = func.copy(name = map.getOrElse(func.name, func.name)))
+    copy(func =
+      func.copy(
+        name = map.getOrElse(func.name, func.name),
+        arrow = func.arrow.copy(ret = func.arrow.ret.map(_.renameVars(map)))
+      )
+    )
 
   override def mapValues(f: ValueRaw => ValueRaw): RawTag =
     copy(
       func.copy(arrow =
         func.arrow.copy(
-          ret = func.arrow.ret.map(_.mapValues(f)),
           body = func.arrow.body.map(_.mapValues(f))
         )
       )

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -292,7 +292,8 @@ case class ClosureTag(
   override def renameExports(map: Map[String, String]): RawTag =
     copy(func =
       func.copy(
-        name = map.getOrElse(func.name, func.name)
+        name = map.getOrElse(func.name, func.name),
+        arrow = func.arrow.copy(ret = func.arrow.ret.map(_.renameVars(map)))
       )
     )
 
@@ -300,7 +301,6 @@ case class ClosureTag(
     copy(
       func.copy(arrow =
         func.arrow.copy(
-          ret = func.arrow.ret.map(_.map(f)),
           body = func.arrow.body.map(_.mapValues(f))
         )
       )

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -292,8 +292,7 @@ case class ClosureTag(
   override def renameExports(map: Map[String, String]): RawTag =
     copy(func =
       func.copy(
-        name = map.getOrElse(func.name, func.name),
-        arrow = func.arrow.copy(ret = func.arrow.ret.map(_.renameVars(map)))
+        name = map.getOrElse(func.name, func.name)
       )
     )
 
@@ -301,6 +300,7 @@ case class ClosureTag(
     copy(
       func.copy(arrow =
         func.arrow.copy(
+          ret = func.arrow.ret.map(_.map(f)),
           body = func.arrow.body.map(_.mapValues(f))
         )
       )

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -292,8 +292,7 @@ case class ClosureTag(
   override def renameExports(map: Map[String, String]): RawTag =
     copy(func =
       func.copy(
-        name = map.getOrElse(func.name, func.name),
-        arrow = func.arrow.copy(ret = func.arrow.ret.map(_.renameVars(map)))
+        name = map.getOrElse(func.name, func.name)
       )
     )
 

--- a/semantics/src/main/scala/aqua/semantics/ExprSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/ExprSem.scala
@@ -13,6 +13,7 @@ import aqua.semantics.rules.locations.LocationsAlgebra
 import aqua.semantics.rules.mangler.ManglerAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
+
 import cats.Monad
 
 object ExprSem {

--- a/semantics/src/main/scala/aqua/semantics/ExprSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/ExprSem.scala
@@ -10,6 +10,7 @@ import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.abilities.AbilitiesAlgebra
 import aqua.semantics.rules.definitions.DefinitionsAlgebra
 import aqua.semantics.rules.locations.LocationsAlgebra
+import aqua.semantics.rules.mangler.ManglerAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
 import cats.Monad
@@ -24,7 +25,8 @@ object ExprSem {
     T: TypesAlgebra[S, G],
     V: ValuesAlgebra[S, G],
     D: DefinitionsAlgebra[S, G],
-    L: LocationsAlgebra[S, G]
+    L: LocationsAlgebra[S, G],
+    M: ManglerAlgebra[G]
   ): Prog[G, Raw] =
     expr match {
       case expr: ServiceIdExpr[S] => new ServiceIdSem(expr).program[G]

--- a/semantics/src/main/scala/aqua/semantics/RawSemantics.scala
+++ b/semantics/src/main/scala/aqua/semantics/RawSemantics.scala
@@ -276,7 +276,8 @@ object RawSemantics extends Logging {
     T: TypesAlgebra[S, G],
     D: DefinitionsAlgebra[S, G],
     L: LocationsAlgebra[S, G],
-    E: ReportAlgebra[S, G]
+    E: ReportAlgebra[S, G],
+    M: ManglerAlgebra[G]
   ): (Expr[S], Chain[G[RawWithToken[S]]]) => Eval[G[RawWithToken[S]]] = (expr, inners) =>
     Eval later ExprSem
       .getProg[S, G](expr)

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
@@ -1,33 +1,26 @@
 package aqua.semantics.expr.func
 
-import aqua.parser.expr.FuncExpr
 import aqua.parser.expr.func.ArrowExpr
-import aqua.parser.lexer.{Arg, DataTypeToken}
 import aqua.raw.Raw
 import aqua.raw.arrow.ArrowRaw
-import aqua.raw.ops.{SeqTag, *}
+import aqua.raw.ops.*
 import aqua.raw.value.*
 import aqua.semantics.Prog
-import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.abilities.AbilitiesAlgebra
 import aqua.semantics.rules.locations.LocationsAlgebra
+import aqua.semantics.rules.mangler.ManglerAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
 import aqua.types.*
-
-import cats.Eval
-import cats.data.{Chain, NonEmptyList}
-import cats.free.{Cofree, Free}
-import cats.data.OptionT
-import cats.syntax.show.*
+import cats.Monad
+import cats.data.Chain
+import cats.free.Cofree
 import cats.syntax.applicative.*
-import cats.syntax.apply.*
-import cats.syntax.foldable.*
 import cats.syntax.bifunctor.*
 import cats.syntax.flatMap.*
+import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.traverse.*
-import cats.{Applicative, Monad}
 
 class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
 
@@ -35,9 +28,7 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
 
   def before[Alg[_]: Monad](implicit
     T: TypesAlgebra[S, Alg],
-    N: NamesAlgebra[S, Alg],
-    A: AbilitiesAlgebra[S, Alg],
-    L: LocationsAlgebra[S, Alg]
+    N: NamesAlgebra[S, Alg]
   ): Alg[ArrowType] = for {
     arrowType <- T.beginArrowScope(arrowTypeExpr)
     // Create local variables
@@ -57,13 +48,11 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
   )(using
     T: TypesAlgebra[S, Alg],
     N: NamesAlgebra[S, Alg],
-    A: AbilitiesAlgebra[S, Alg],
-    L: LocationsAlgebra[S, Alg]
+    M: ManglerAlgebra[Alg]
   ): Alg[Raw] = for {
     streamsInScope <- N.streamsDefinedWithinScope()
     retValues <- T.endArrowScope(expr.arrowTypeExpr)
-    retValuesDerivedFrom <- N.getDerivedFrom(retValues.map(_.varNames))
-    res = bodyGen match {
+    res <- bodyGen match {
       case FuncOp(bodyModel) =>
         // TODO: wrap with local on...via...
         val retsAndArgs = retValues zip funcArrow.codomain.toList
@@ -77,51 +66,63 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
         val localStreams = streamsInScope -- dataArgsNames -- streamsThatReturnAsStreams
 
         // process stream that returns as not streams and all Apply*Raw
-        val (bodyRets, retVals) = retsAndArgs.mapWithIndex {
-          case ((v @ VarRaw(_, StreamType(_)), StreamType(_)), _) =>
-            (Chain.empty, v)
+        retsAndArgs.traverse {
+          case (v @ VarRaw(_, StreamType(_)), StreamType(_)) =>
+            (Chain.empty, v).pure[Alg]
           // canonicalize and change return value
-          case ((VarRaw(streamName, streamType @ StreamType(streamElement)), _), idx) =>
-            val canonReturnVar = VarRaw(s"-$streamName-fix-$idx", CanonStreamType(streamElement))
-            val returnVar = VarRaw(s"-$streamName-flat-$idx", ArrayType(streamElement))
-            val body = Chain(
-              CanonicalizeTag(
-                VarRaw(streamName, streamType),
-                Call.Export(canonReturnVar.name, canonReturnVar.`type`)
-              ).leaf,
-              FlattenTag(
-                canonReturnVar,
-                returnVar.name
-              ).leaf
-            )
+          case (VarRaw(streamName, streamType @ StreamType(streamElement)), _) =>
+            for {
+              canonName <- M.rename(s"-$streamName-fix")
+              returnVarName <- M.rename(s"-$streamName-flat")
+            } yield {
+              val canonReturnVar = VarRaw(canonName, CanonStreamType(streamElement))
+              val returnVar = VarRaw(returnVarName, ArrayType(streamElement))
+              val body = Chain(
+                CanonicalizeTag(
+                  VarRaw(streamName, streamType),
+                  Call.Export(canonReturnVar.name, canonReturnVar.`type`)
+                ).leaf,
+                FlattenTag(
+                  canonReturnVar,
+                  returnVar.name
+                ).leaf
+              )
 
-            (body, returnVar)
+              (body, returnVar)
+            }
+
           // assign and change return value for all `Apply*Raw`
-          case ((v: ValueRaw.ApplyRaw, _), idx) =>
-            val assignedReturnVar = VarRaw(s"-return-fix-$idx", v.`type`)
-            val body = Chain.one(
-              AssignmentTag(
-                v,
-                assignedReturnVar.name
-              ).leaf
-            )
+          case (v: ValueRaw.ApplyRaw, _) =>
+            for {
+              assignedReturnName <- M.rename(s"-return-fix")
+            } yield {
+              val assignedReturnVar = VarRaw(assignedReturnName, v.`type`)
 
-            (body, assignedReturnVar)
-          case ((v, _), _) => (Chain.empty, v)
-        }.unzip.leftMap(_.combineAll)
+              val body = Chain.one(
+                AssignmentTag(
+                  v,
+                  assignedReturnVar.name
+                ).leaf
+              )
 
-        val bodyModified = SeqTag.wrap(
-          bodyModel +: bodyRets
-        )
+              (body, assignedReturnVar)
+            }
 
-        // wrap streams with restrictions
-        val bodyWithRestrictions = localStreams.foldLeft(bodyModified) {
-          case (bm, (streamName, streamType)) =>
-            RestrictionTag(streamName, streamType).wrap(bm)
+          case (v, _) => (Chain.empty, v).pure[Alg]
+        }.map(_.unzip.leftMap(_.combineAll)).map { case (bodyRets, retVals) =>
+          val bodyModified = SeqTag.wrap(
+            bodyModel +: bodyRets
+          )
+
+          // wrap streams with restrictions
+          val bodyWithRestrictions =
+            localStreams.foldLeft(bodyModified) { case (bm, (streamName, streamType)) =>
+              RestrictionTag(streamName, streamType).wrap(bm)
+            }
+          ArrowRaw(funcArrow, retVals, bodyWithRestrictions)
         }
 
-        ArrowRaw(funcArrow, retVals, bodyWithRestrictions)
-      case _ => Raw.error("Invalid arrow body")
+      case _ => Raw.error("Invalid arrow body").pure[Alg]
     }
   } yield res
 
@@ -129,7 +130,8 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
     T: TypesAlgebra[S, Alg],
     N: NamesAlgebra[S, Alg],
     A: AbilitiesAlgebra[S, Alg],
-    L: LocationsAlgebra[S, Alg]
+    L: LocationsAlgebra[S, Alg],
+    M: ManglerAlgebra[Alg]
   ): Prog[Alg, Raw] =
     Prog
       .around(

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
@@ -12,6 +12,7 @@ import aqua.semantics.rules.mangler.ManglerAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
 import aqua.types.*
+
 import cats.Monad
 import cats.data.Chain
 import cats.free.Cofree


### PR DESCRIPTION
## Description
Returning multiple closures from one function generates incorrect AIR
```
func create(a: i8, b: i8) -> i8 -> i8, i8:
    arrow = (c: i8) -> i8, i8:
        <- a, b
    <- arrow

func test() -> i8, i8, i8, i8, i8, i8:
    Ab <- create(1, 2)
    ab <- create(3, 4)
    AB <- create(5, 6)
    <- res1, res2, res3, res4, res5, res6
```

## Implementation Details
There were two problems:
- return value names weren't renamed in ArrowInliner
- generated in ArrowSem names overlapped

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

