### PR TITLE
feat(compiler): Allow omitting field name in struct creation [LNG-261]

### DIFF
--- a/parser/src/main/scala/aqua/parser/lexer/NamedArg.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/NamedArg.scala
@@ -51,7 +51,7 @@ object NamedArg {
       VarToken.variable.between(` *`, `/s*`)
     ).map(NamedArg.Short.apply)
 
-  private val namedArg: P[NamedArg[S]] =
+  val namedArg: P[NamedArg[S]] =
     namedArgFull.backtrack | namedArgShort
 
   val namedArgs: P[NonEmptyList[NamedArg[S]]] =

--- a/parser/src/main/scala/aqua/parser/lexer/NamedArg.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/NamedArg.scala
@@ -1,0 +1,49 @@
+package aqua.parser.lexer
+
+import aqua.parser.lift.Span.S
+import aqua.parser.lexer.Token.*
+
+import cats.data.NonEmptyList
+import cats.parse.Parser as P
+import cats.syntax.functor.*
+import cats.Comonad
+import cats.arrow.FunctionK
+
+enum NamedArg[F[_]] extends Token[F] {
+  // for `name = value`
+  case Full(name: Name[F], value: ValueToken[F])
+  // for just `name` (short for `name = name`)
+  case Short(variable: VarToken[F])
+
+  override def as[T](v: T): F[T] = this match {
+    case Full(name, value) => name.as(v)
+    case Short(variable) => variable.as(v)
+  }
+
+  override def mapK[K[_]: Comonad](fk: FunctionK[F, K]): NamedArg[K] =
+    this match {
+      case Full(name, value) => Full(name.mapK(fk), value.mapK(fk))
+      case Short(variable) => Short(variable.mapK(fk))
+    }
+}
+
+object NamedArg {
+
+  private val namedArgFull: P[NamedArg.Full[S]] =
+    P.defer(
+      (Name.p.between(` *`, `/s*`) <*
+        `=`.between(` *`, `/s*`)) ~
+        ValueToken.`value`.between(` *`, `/s*`)
+    ).map(NamedArg.Full.apply)
+
+  private val namedArgShort: P[NamedArg.Short[S]] =
+    P.defer(
+      VarToken.variable.between(` *`, `/s*`)
+    ).map(NamedArg.Short.apply)
+
+  private val namedArg: P[NamedArg[S]] =
+    namedArgFull.backtrack | namedArgShort
+
+  val namedArgs: P[NonEmptyList[NamedArg[S]]] =
+    P.defer(` `.?.with1 ~ `(` ~ `/s*` *> comma(namedArg) <* `/s*` *> `)`)
+}

--- a/parser/src/main/scala/aqua/parser/lexer/NamedArg.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/NamedArg.scala
@@ -15,6 +15,16 @@ enum NamedArg[F[_]] extends Token[F] {
   // for just `name` (short for `name = name`)
   case Short(variable: VarToken[F])
 
+  lazy val argName: Name[F] = this match {
+    case Full(name, _) => name
+    case Short(variable) => variable.name
+  }
+
+  lazy val argValue: ValueToken[F] = this match {
+    case Full(_, value) => value
+    case Short(variable) => variable
+  }
+
   override def as[T](v: T): F[T] = this match {
     case Full(name, value) => name.as(v)
     case Short(variable) => variable.as(v)

--- a/parser/src/main/scala/aqua/parser/lexer/Token.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/Token.scala
@@ -1,6 +1,7 @@
 package aqua.parser.lexer
 
 import aqua.parser.lift.Span.S
+
 import cats.data.NonEmptyList
 import cats.parse.{Accumulator0, Parser as P, Parser0 as P0}
 import cats.{~>, Comonad, Functor}
@@ -119,18 +120,6 @@ object Token {
   val `<=` : P[Unit] = P.string("<=")
   val `<-` : P[Unit] = P.string("<-")
   val `/s*` : P0[Unit] = ` \n+`.backtrack | ` *`.void
-
-  val namedArg: P[(String, ValueToken[S])] =
-    P.defer(
-      `name`.between(` *`, `/s*`) ~
-        `=`.between(` *`, `/s*`).void ~
-        ValueToken.`value`.between(` *`, `/s*`)
-    ).map { case ((name, _), vt) =>
-      (name, vt)
-    }
-
-  val namedArgs: P[NonEmptyList[(String, ValueToken[S])]] =
-    P.defer(` `.?.with1 ~ `(` ~ `/s*` *> comma(namedArg) <* `/s*` *> `)`)
 
   case class LiftToken[F[_]: Functor, A](point: F[A]) extends Token[F] {
     override def as[T](v: T): F[T] = Functor[F].as(point, v)

--- a/parser/src/main/scala/aqua/parser/lexer/ValueToken.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/ValueToken.scala
@@ -3,6 +3,7 @@ package aqua.parser.lexer
 import aqua.parser.Expr
 import aqua.parser.head.FilenameExpr
 import aqua.parser.lexer.Token.*
+import aqua.parser.lexer.NamedArg.namedArgs
 import aqua.parser.lift.LiftParser
 import aqua.parser.lift.LiftParser.*
 import aqua.types.LiteralType
@@ -260,7 +261,7 @@ object CallArrowToken {
 
 case class NamedValueToken[F[_]: Comonad](
   typeName: NamedTypeToken[F],
-  fields: NonEmptyMap[String, ValueToken[F]]
+  fields: NonEmptyList[NamedArg[F]]
 ) extends ValueToken[F] {
 
   override def mapK[K[_]: Comonad](fk: F ~> K): NamedValueToken[K] =
@@ -277,7 +278,7 @@ object NamedValueToken {
         "Missing braces '()' after the struct type"
       )
       .map { case (dn, args) =>
-        NamedValueToken(NamedTypeToken(dn), args.toNem)
+        NamedValueToken(NamedTypeToken(dn), args)
       }
 }
 

--- a/parser/src/test/scala/aqua/parser/AbilityValueExprSpec.scala
+++ b/parser/src/test/scala/aqua/parser/AbilityValueExprSpec.scala
@@ -19,11 +19,14 @@ class AbilityValueExprSpec extends AnyFlatSpec with Matchers with AquaSpec {
     parseData(str) should be(
       NamedValueToken(
         NamedTypeToken[Id]("AbilityA"),
-        NonEmptyMap.of(
-          "v1" -> toNumber(1),
-          "f1" -> PropertyToken[Id](
-            VarToken(toName("input")),
-            NonEmptyList.one(IntoField("arrow"))
+        NonEmptyList.of(
+          NamedArg.Full(toName("v1"), toNumber(1)),
+          NamedArg.Full(
+            toName("f1"),
+            PropertyToken(
+              VarToken(toName("input")),
+              NonEmptyList.one(IntoField("arrow"))
+            )
           )
         )
       )

--- a/parser/src/test/scala/aqua/parser/lexer/PropertyOpSpec.scala
+++ b/parser/src/test/scala/aqua/parser/lexer/PropertyOpSpec.scala
@@ -42,10 +42,10 @@ class PropertyOpSpec extends AnyFlatSpec with Matchers with EitherValues {
     PropertyOp.ops.parseAll("!-1").isLeft shouldBe true
   }
 
-  "copy ops" should "parse" in {
-    val opsP = (s: String) => PropertyOp.ops.parseAll(s).value.map(_.mapK(spanToId))
+  def copyOpsP(s: String) = PropertyOp.ops.parseAll(s).value.map(_.mapK(spanToId))
 
-    opsP(".copy(a = \"str\", b = 12)") should be(
+  "copy ops" should "parse one copy" in {
+    copyOpsP(".copy(a = \"str\", b = 12)") should be(
       NonEmptyList.of(
         IntoCopy[Id](
           (),
@@ -56,8 +56,10 @@ class PropertyOpSpec extends AnyFlatSpec with Matchers with EitherValues {
         )
       )
     )
+  }
 
-    opsP(".copy(a = \"str\", b = 12).copy(c = 54, d = someVar)") should be(
+  it should "parse sequential copy" in {
+    copyOpsP(".copy(a = \"str\", b = 12).copy(c = 54, d = someVar)") should be(
       NonEmptyList.of(
         IntoCopy[Id](
           (),
@@ -75,6 +77,24 @@ class PropertyOpSpec extends AnyFlatSpec with Matchers with EitherValues {
         )
       )
     )
+  }
+
+  it should "parse mixed args in copy" in {
+    val args = List(
+      "a = \"str\"" -> NamedArg.Full(toName("a"), toStr("str")),
+      "b = 12" -> NamedArg.Full(toName("b"), toNumber(12)),
+      "c" -> NamedArg.Short(toVar("c")),
+      "d" -> NamedArg.Short(toVar("d"))
+    )
+
+    args.toSet.subsets().filter(_.nonEmpty).flatMap(_.toList.permutations).foreach { args =>
+      val str = args.map(_._1).mkString(".copy(", ", ", ")")
+      val expected = NonEmptyList.of(
+        IntoCopy[Id]((), NonEmptyList.fromListUnsafe(args.map(_._2)))
+      )
+
+      copyOpsP(str) should be(expected)
+    }
   }
 
 }

--- a/parser/src/test/scala/aqua/parser/lexer/PropertyOpSpec.scala
+++ b/parser/src/test/scala/aqua/parser/lexer/PropertyOpSpec.scala
@@ -49,9 +49,9 @@ class PropertyOpSpec extends AnyFlatSpec with Matchers with EitherValues {
       NonEmptyList.of(
         IntoCopy[Id](
           (),
-          NonEmptyMap.of(
-            "a" -> LiteralToken("\"str\"", LiteralType.string),
-            "b" -> toNumber(12)
+          NonEmptyList.of(
+            NamedArg.Full(toName("a"), toStr("str")),
+            NamedArg.Full(toName("b"), toNumber(12))
           )
         )
       )
@@ -61,16 +61,16 @@ class PropertyOpSpec extends AnyFlatSpec with Matchers with EitherValues {
       NonEmptyList.of(
         IntoCopy[Id](
           (),
-          NonEmptyMap.of(
-            "a" -> LiteralToken("\"str\"", LiteralType.string),
-            "b" -> toNumber(12)
+          NonEmptyList.of(
+            NamedArg.Full(toName("a"), toStr("str")),
+            NamedArg.Full(toName("b"), toNumber(12))
           )
         ),
         IntoCopy[Id](
           (),
-          NonEmptyMap.of(
-            "c" -> toNumber(54),
-            "d" -> VarToken("someVar")
+          NonEmptyList.of(
+            NamedArg.Full(toName("c"), toNumber(54)),
+            NamedArg.Full(toName("d"), toVar("someVar"))
           )
         )
       )

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
@@ -37,10 +37,11 @@ trait TypesAlgebra[S[_], Alg[_]] {
   def resolveIndex(rootT: Type, op: IntoIndex[S], idx: ValueRaw): Alg[Option[PropertyRaw]]
 
   def resolveCopy(
+    token: IntoCopy[S],
     rootT: Type,
-    op: IntoCopy[S],
-    fields: NonEmptyMap[String, ValueRaw]
+    fields: NonEmptyList[(NamedArg[S], ValueRaw)]
   ): Alg[Option[PropertyRaw]]
+
   def resolveField(rootT: Type, op: IntoField[S]): Alg[Option[PropertyRaw]]
 
   def resolveArrow(

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -216,7 +216,7 @@ class TypesInterpreter[S[_], X](using
             )
             .as(None)
         ) {
-          case at@ArrowType(_, _) =>
+          case at @ ArrowType(_, _) =>
             locations
               .pointFieldLocation(name, op.name.value, op)
               .as(Some(IntoArrowRaw(op.name.value, at, arguments)))
@@ -245,22 +245,34 @@ class TypesInterpreter[S[_], X](using
 
   // TODO actually it's stateless, exists there just for reporting needs
   override def resolveCopy(
+    token: IntoCopy[S],
     rootT: Type,
-    op: IntoCopy[S],
-    fields: NonEmptyMap[String, ValueRaw]
+    args: NonEmptyList[(NamedArg[S], ValueRaw)]
   ): State[X, Option[PropertyRaw]] =
     rootT match {
       case st: StructType =>
-        fields.toSortedMap.toList.traverse { case (fieldName, value) =>
+        // TODO: Check for duplicate fields
+        args.forallM { case (arg, value) =>
+          val fieldName = arg.argName.value
           st.fields.lookup(fieldName) match {
             case Some(t) =>
-              ensureTypeMatches(op.fields.lookup(fieldName).getOrElse(op), t, value.`type`)
-            case None => report.error(op, s"No field with name '$fieldName' in $rootT").as(false)
+              ensureTypeMatches(arg.argValue, t, value.`type`)
+            case None =>
+              report.error(arg.argName, s"No field with name '$fieldName' in $rootT").as(false)
           }
-        }.map(res => if (res.forall(identity)) Some(IntoCopyRaw(st, fields)) else None)
+        }.map(
+          Option.when(_)(
+            IntoCopyRaw(
+              st,
+              args.map { case (arg, value) =>
+                arg.argName.value -> value
+              }.toNem
+            )
+          )
+        )
 
       case _ =>
-        report.error(op, s"Expected $rootT to be a data type").as(None)
+        report.error(token, s"Expected $rootT to be a data type").as(None)
     }
 
   // TODO actually it's stateless, exists there just for reporting needs
@@ -339,12 +351,12 @@ class TypesInterpreter[S[_], X](using
               )
               .as(false)
           } else {
-            valueFields.toSortedMap.toList.traverse { (name, `type`) =>
+            valueFields.toSortedMap.toList.forallM { (name, `type`) =>
               typeFields.lookup(name) match {
                 case Some(t) =>
                   val nextToken = token match {
                     case NamedValueToken(_, fields) =>
-                      fields.lookup(name).getOrElse(token)
+                      fields.find(_.argName.value == name).getOrElse(token)
                     // TODO: Is it needed?
                     case PropertyToken(_, properties) =>
                       properties.last
@@ -359,7 +371,7 @@ class TypesInterpreter[S[_], X](using
                     )
                     .as(false)
               }
-            }.map(_.forall(identity))
+            }
           }
         case _ =>
           val notes =

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -251,7 +251,6 @@ class TypesInterpreter[S[_], X](using
   ): State[X, Option[PropertyRaw]] =
     rootT match {
       case st: StructType =>
-        // TODO: Check for duplicate fields
         args.forallM { case (arg, value) =>
           val fieldName = arg.argName.value
           st.fields.lookup(fieldName) match {

--- a/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
@@ -5,7 +5,7 @@ import aqua.parser.Ast
 import aqua.raw.ops.{Call, CallArrowRawTag, FuncOp, OnTag, ParTag, RawTag, SeqGroupTag, SeqTag}
 import aqua.parser.Parser
 import aqua.parser.lift.{LiftParser, Span}
-import aqua.raw.value.{ApplyBinaryOpRaw, LiteralRaw, ValueRaw, VarRaw}
+import aqua.raw.value.*
 import aqua.types.*
 import aqua.raw.ops.*
 
@@ -22,8 +22,6 @@ import cats.free.Cofree
 import cats.data.State
 import cats.Eval
 import org.scalactic.anyvals.NonEmptyList
-import aqua.raw.value.MakeStructRaw
-import aqua.raw.value.AbilityRaw
 
 class SemanticsSpec extends AnyFlatSpec with Matchers with Inside {
 

--- a/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
@@ -21,7 +21,6 @@ import cats.data.Validated
 import cats.free.Cofree
 import cats.data.State
 import cats.Eval
-import org.scalactic.anyvals.NonEmptyList
 
 class SemanticsSpec extends AnyFlatSpec with Matchers with Inside {
 


### PR DESCRIPTION
## Description
Allow omitting field name in ability or data construction if it is the same as the passed variable for convenience:
```
field = 42
st = Struct(field) -- same as Struct(field = field)
```
Also the same for `.copy` method.

## Implementation Details
* Rewrite parsing to accept short arguments in `.copy` and constructors
* Process parsing results on semantics stage accordingly

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

