### PR TITLE
fix(compiler): Throw an error when comparing an alias and a named type with the same name [LNG-231]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,35 +1,6 @@
-aqua A
+alias Troll: u32
 
-export bugLNG260
+func test() -> i8:
+  MyAbility = Troll(f = "sf")
 
-func create(a: i8) -> -> i8:
-    closureArrow = () -> i8:
-        <- a
-    <- closureArrow
-
-func test() -> i8, i8:
-    arr1 <- create(1)
-    arr2 <- create(2)
-    <- arr1(), arr2()
-
-func cmp(a: i32, b: i32, pred: i8 -> bool) -> bool:
-  result: ?bool
-
-  if a < b:
-    result <- pred(-1)
-  else:
-    if a == b:
-      result <- pred(0)
-    else:
-      result <- pred(1)
-
-  <- result!
-
-func gt(a: i32, b: i32) -> bool:
-  pred = (ord: i8) -> bool:
-        <- ord > 0
-
-  <- cmp(a, b, pred)
-
-func bugLNG260(a: i32, b: i32) -> bool:
-  <- gt(a, b)
+  <- 42

--- a/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
+++ b/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
@@ -618,9 +618,6 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
       None
     )
 
-    println("testFunc: ")
-    println(testFunc.body.show)
-
     val model = ArrowInliner
       .callArrow[InliningState](testFunc, CallModel(Nil, Nil))
       .runA(InliningState())

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -134,7 +134,6 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
                   ability.copy(fields = fieldsGivenTypes),
                   AbilityRaw(fieldsGiven, ability)
                 ).some
-              case _ => none
             }
           )
           (genType, genData) = generated

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -124,9 +124,8 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
           fieldsGivenTypes = fieldsGiven.map(_.`type`)
           data <- resolvedType match {
             case struct: StructType =>
-              val t = struct.copy(fields = fieldsGivenTypes)
               OptionT.whenM(
-                T.ensureTypeMatches(dvt, resolvedType, t)
+                T.ensureTypeMatches(dvt, resolvedType, struct.copy(fields = fieldsGivenTypes))
               )(MakeStructRaw(fieldsGiven, struct).pure)
             case ability: AbilityType =>
               OptionT.whenM(

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
@@ -52,7 +52,7 @@ trait TypesAlgebra[S[_], Alg[_]] {
 
   def ensureValuesComparable(token: Token[S], left: Type, right: Type): Alg[Boolean]
 
-  def ensureTypeMatches(token: Token[S], expected: Type, givenType: Type): Alg[Boolean]
+  def ensureTypeMatches(token: Token[S], expected: Type, givenType: Type, alias: Option[String] = None): Alg[Boolean]
 
   def ensureTypeIsCollectible(token: Token[S], givenType: Type): Alg[Boolean]
 

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
@@ -10,6 +10,8 @@ import cats.data.NonEmptyList
 trait TypesAlgebra[S[_], Alg[_]] {
 
   def resolveType(token: TypeToken[S]): Alg[Option[Type]]
+  
+  def resolveNamedType(token: TypeToken[S]): Alg[Option[Type]]
 
   def getType(name: String): Alg[Option[Type]]
 
@@ -52,7 +54,7 @@ trait TypesAlgebra[S[_], Alg[_]] {
 
   def ensureValuesComparable(token: Token[S], left: Type, right: Type): Alg[Boolean]
 
-  def ensureTypeMatches(token: Token[S], expected: Type, givenType: Type, alias: Option[String] = None): Alg[Boolean]
+  def ensureTypeMatches(token: Token[S], expected: Type, givenType: Type): Alg[Boolean]
 
   def ensureTypeIsCollectible(token: Token[S], givenType: Type): Alg[Boolean]
 

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
@@ -11,7 +11,7 @@ trait TypesAlgebra[S[_], Alg[_]] {
 
   def resolveType(token: TypeToken[S]): Alg[Option[Type]]
   
-  def resolveNamedType(token: TypeToken[S]): Alg[Option[Type]]
+  def resolveNamedType(token: TypeToken[S]): Alg[Option[AbilityType | StructType]]
 
   def getType(name: String): Alg[Option[Type]]
 

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -58,7 +58,7 @@ class TypesInterpreter[S[_], X](using
         report.error(token, s"Unresolved type").as(None)
     }
 
-  def resolveNamedType(token: TypeToken[S]): State[X, Option[Type]] =
+  def resolveNamedType(token: TypeToken[S]): State[X, Option[AbilityType | StructType]] =
     resolveType(token).flatMap(_.flatTraverse {
       case t: (AbilityType | StructType) => Option(t).pure
       case _ => report.error(token, "Type must be an ability or a data").as(None)

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -59,7 +59,7 @@ class TypesInterpreter[S[_], X](using
     }
 
   def resolveNamedType(token: TypeToken[S]): State[X, Option[Type]] =
-    resolveType(token).flatMap(a => a.flatTraverse {
+    resolveType(token).flatMap(_.flatTraverse {
       case t: (AbilityType | StructType) => Option(t).pure
       case _ => report.error(token, "Type must be an ability or a data").as(None)
     })

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -333,10 +333,12 @@ class TypesInterpreter[S[_], X](using
   override def ensureTypeMatches(
     token: Token[S],
     expected: Type,
-    givenType: Type
+    givenType: Type,
+    alias: Option[String] = None
   ): State[X, Boolean] =
     if (expected.acceptsValueOf(givenType)) State.pure(true)
     else {
+      val expectedStr = alias.map(a => s"$a, that is an alias of '$expected'").getOrElse(expected.toString)
       (expected, givenType) match {
         case (valueNamedType: NamedType, typeNamedType: NamedType) =>
           val valueFields = valueNamedType.fields
@@ -346,7 +348,7 @@ class TypesInterpreter[S[_], X](using
             report
               .error(
                 token,
-                s"Number of fields doesn't match the data type, expected: $expected, given: $givenType"
+                s"Number of fields doesn't match the data type, expected: $expectedStr, given: $givenType"
               )
               .as(false)
           } else {
@@ -366,7 +368,7 @@ class TypesInterpreter[S[_], X](using
                   report
                     .error(
                       token,
-                      s"Wrong value type, expected: $expected, given: $givenType"
+                      s"Wrong value type, expected: $expectedStr, given: $givenType"
                     )
                     .as(false)
               }
@@ -384,7 +386,7 @@ class TypesInterpreter[S[_], X](using
           report
             .error(
               token,
-              "Types mismatch." :: s"expected:   $expected" :: s"given:      $givenType" :: Nil ++ notes
+              "Types mismatch." :: s"expected:   $expectedStr" :: s"given:      $givenType" :: Nil ++ notes
             )
             .as(false)
       }


### PR DESCRIPTION
## Description
Throw compilation error on a code like this:
```
alias NamedT: u32

func test():
  MyAbility = NamedT(randomField = "sf")
```

## Implementation Details
Don't ignore named type comparison with aliases, improve type checking error.

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

