### PR TITLE
feat(compiler): Always generate `last` argument of `fold` [LNG-265]

### DIFF
--- a/backend/air/src/main/scala/aqua/backend/air/Air.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/Air.scala
@@ -93,7 +93,7 @@ object Air {
     iterable: DataView,
     label: String,
     instruction: Air,
-    lastNextInstruction: Option[Air]
+    lastNextInstruction: Air
   ) extends Air(Keyword.Fold)
 
   case class Match(left: DataView, right: DataView, instruction: Air) extends Air(Keyword.Match)
@@ -137,7 +137,7 @@ object Air {
             case Air.Next(label) ⇒ s" $label"
             case Air.New(item, inst) ⇒ s" ${item.show}\n${showNext(inst)}$space"
             case Air.Fold(iter, label, inst, lastInst) ⇒
-              val l = lastInst.map(a => show(depth + 1, a)).getOrElse("")
+              val l = show(depth + 1, lastInst)
               s" ${iter.show} $label\n${showNext(inst)}$l$space"
             case Air.Match(left, right, inst) ⇒
               s" ${left.show} ${right.show}\n${showNext(inst)}$space"

--- a/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/AirGen.scala
@@ -94,9 +94,9 @@ object AirGen extends Logging {
         )
 
       case FoldRes(item, iterable, mode) =>
-        val m = mode.map {
-          case ForModel.Mode.Null => NullGen
-          case ForModel.Mode.Never => NeverGen
+        val m = mode match {
+          case FoldRes.Mode.Null => NullGen
+          case FoldRes.Mode.Never => NeverGen
         }
         Eval later ForGen(valueToData(iterable), item, opsToSingle(ops), m)
       case RestrictionRes(item, itemType) =>
@@ -202,9 +202,8 @@ case class MatchMismatchGen(
     else Air.Mismatch(left, right, body.generate)
 }
 
-case class ForGen(iterable: DataView, item: String, body: AirGen, mode: Option[AirGen])
-    extends AirGen {
-  override def generate: Air = Air.Fold(iterable, item, body.generate, mode.map(_.generate))
+case class ForGen(iterable: DataView, item: String, body: AirGen, mode: AirGen) extends AirGen {
+  override def generate: Air = Air.Fold(iterable, item, body.generate, mode.generate)
 }
 
 case class NewGen(name: String, body: AirGen) extends AirGen {

--- a/compiler/src/test/scala/aqua/compiler/AquaCompilerSpec.scala
+++ b/compiler/src/test/scala/aqua/compiler/AquaCompilerSpec.scala
@@ -169,34 +169,36 @@ class AquaCompilerSpec extends AnyFlatSpec with Matchers with Inside {
             RestrictionRes(results.name, resultsType).wrap(
               SeqRes.wrap(
                 ParRes.wrap(
-                  FoldRes(peer.name, peers, ForModel.Mode.Never.some).wrap(
-                    ParRes.wrap(
-                      XorRes.wrap(
-                        // better if first relay will be outside `for`
-                        SeqRes.wrap(
-                          through(ValueModel.fromRaw(relay)),
-                          CallServiceRes(
-                            LiteralModel.fromRaw(LiteralRaw.quote("op")),
-                            "identity",
-                            CallRes(
-                              LiteralModel.fromRaw(LiteralRaw.quote("hahahahah")) :: Nil,
-                              Some(CallModel.Export(retVar.name, retVar.`type`))
-                            ),
-                            peer
-                          ).leaf,
-                          ApRes(retVar, CallModel.Export(results.name, results.`type`)).leaf,
-                          through(ValueModel.fromRaw(relay)),
-                          through(initPeer)
+                  FoldRes
+                    .lastNever(peer.name, peers)
+                    .wrap(
+                      ParRes.wrap(
+                        XorRes.wrap(
+                          // better if first relay will be outside `for`
+                          SeqRes.wrap(
+                            through(ValueModel.fromRaw(relay)),
+                            CallServiceRes(
+                              LiteralModel.fromRaw(LiteralRaw.quote("op")),
+                              "identity",
+                              CallRes(
+                                LiteralModel.fromRaw(LiteralRaw.quote("hahahahah")) :: Nil,
+                                Some(CallModel.Export(retVar.name, retVar.`type`))
+                              ),
+                              peer
+                            ).leaf,
+                            ApRes(retVar, CallModel.Export(results.name, results.`type`)).leaf,
+                            through(ValueModel.fromRaw(relay)),
+                            through(initPeer)
+                          ),
+                          SeqRes.wrap(
+                            through(ValueModel.fromRaw(relay)),
+                            through(initPeer),
+                            failErrorRes
+                          )
                         ),
-                        SeqRes.wrap(
-                          through(ValueModel.fromRaw(relay)),
-                          through(initPeer),
-                          failErrorRes
-                        )
-                      ),
-                      NextRes(peer.name).leaf
+                        NextRes(peer.name).leaf
+                      )
                     )
-                  )
                 ),
                 join(results, LiteralModel.number(3)), // Compiler optimized addition
                 CanonRes(

--- a/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
@@ -227,12 +227,12 @@ object TagInliner extends Logging {
               )
           }
           _ <- Exports[S].resolved(item, VarModel(n, elementType))
-          m = mode.map {
-            case ForTag.Mode.Wait => ForModel.Mode.Never
-            case ForTag.Mode.Pass => ForModel.Mode.Null
+          modeModel = mode match {
+            case ForTag.Mode.Blocking => ForModel.Mode.Never
+            case ForTag.Mode.NonBlocking => ForModel.Mode.Null
           }
         } yield TagInlined.Single(
-          model = ForModel(n, v, m),
+          model = ForModel(n, v, modeModel),
           prefix = p
         )
 

--- a/model/inline/src/main/scala/aqua/model/inline/raw/StreamGateInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/raw/StreamGateInliner.scala
@@ -56,7 +56,7 @@ object StreamGateInliner extends Logging {
     val resultCanon = VarModel(canonName, CanonStreamType(streamType.element))
 
     RestrictionModel(varSTest.name, streamType).wrap(
-      ForModel(iter.name, VarModel(streamName, streamType), ForModel.Mode.Never.some).wrap(
+      ForModel(iter.name, VarModel(streamName, streamType), ForModel.Mode.Never).wrap(
         PushToStreamModel(
           iter,
           CallModel.Export(varSTest.name, varSTest.`type`)

--- a/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
+++ b/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
@@ -1936,8 +1936,10 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
         .leaf
     )
 
-    val foldOp =
-      ForTag(iVar.name, array, ForTag.Mode.Blocking.some).wrap(inFold, NextTag(iVar.name).leaf)
+    val foldOp = ForTag(iVar.name, array, ForTag.Mode.Blocking).wrap(
+      inFold,
+      NextTag(iVar.name).leaf
+    )
 
     val model: OpModel.Tree = ArrowInliner
       .callArrow[InliningState](
@@ -1963,7 +1965,7 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
       ._2
 
     model.equalsOrShowDiff(
-      ForModel(iVar0.name, ValueModel.fromRaw(array), ForModel.Mode.Never.some).wrap(
+      ForModel(iVar0.name, ValueModel.fromRaw(array), ForModel.Mode.Never).wrap(
         CallServiceModel(
           LiteralModel.fromRaw(serviceId),
           fnName,

--- a/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
+++ b/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
@@ -1937,7 +1937,7 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
     )
 
     val foldOp =
-      ForTag(iVar.name, array, ForTag.Mode.Wait.some).wrap(inFold, NextTag(iVar.name).leaf)
+      ForTag(iVar.name, array, ForTag.Mode.Blocking.some).wrap(inFold, NextTag(iVar.name).leaf)
 
     val model: OpModel.Tree = ArrowInliner
       .callArrow[InliningState](

--- a/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
+++ b/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
@@ -2064,10 +2064,12 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
         .leaf
     )
 
-    val foldOp = ForTag(iVar.name, array, ForTag.Mode.Blocking).wrap(
-      inFold,
-      NextTag(iVar.name).leaf
-    )
+    val foldOp = ForTag
+      .blocking(iVar.name, array)
+      .wrap(
+        inFold,
+        NextTag(iVar.name).leaf
+      )
 
     val model: OpModel.Tree = ArrowInliner
       .callArrow[InliningState](
@@ -2093,14 +2095,16 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
       ._2
 
     model.equalsOrShowDiff(
-      ForModel(iVar0.name, ValueModel.fromRaw(array), ForModel.Mode.Never).wrap(
-        CallServiceModel(
-          LiteralModel.fromRaw(serviceId),
-          fnName,
-          CallModel(LiteralModel.number(1) :: Nil, Nil)
-        ).leaf,
-        NextModel(iVar0.name).leaf
-      )
+      ForModel
+        .neverMode(iVar0.name, ValueModel.fromRaw(array))
+        .wrap(
+          CallServiceModel(
+            LiteralModel.fromRaw(serviceId),
+            fnName,
+            CallModel(LiteralModel.number(1) :: Nil, Nil)
+          ).leaf,
+          NextModel(iVar0.name).leaf
+        )
     ) should be(true)
   }
 

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -168,8 +168,7 @@ case class RestrictionTag(name: String, `type`: DataType) extends SeqGroupTag {
     copy(name = map.getOrElse(name, name))
 }
 
-case class ForTag(item: String, iterable: ValueRaw, mode: Option[ForTag.Mode] = None)
-    extends SeqGroupTag {
+case class ForTag(item: String, iterable: ValueRaw, mode: ForTag.Mode) extends SeqGroupTag {
 
   override def restrictsVarNames: Set[String] = Set(item)
 
@@ -185,9 +184,15 @@ case class ForTag(item: String, iterable: ValueRaw, mode: Option[ForTag.Mode] = 
 object ForTag {
 
   enum Mode {
-    case Wait
-    case Pass
+    case Blocking
+    case NonBlocking
   }
+
+  def blocking(item: String, iterable: ValueRaw): ForTag =
+    ForTag(item, iterable, Mode.Blocking)
+
+  def nonBlocking(item: String, iterable: ValueRaw): ForTag =
+    ForTag(item, iterable, Mode.NonBlocking)
 }
 
 case class CallArrowRawTag(

--- a/model/res/src/main/scala/aqua/res/MakeRes.scala
+++ b/model/res/src/main/scala/aqua/res/MakeRes.scala
@@ -46,7 +46,13 @@ object MakeRes {
     case SeqModel | _: OnModel | _: ApplyTopologyModel => SeqRes.leaf
     case MatchMismatchModel(a, b, s) =>
       MatchMismatchRes(a, b, s).leaf
-    case ForModel(item, iter, mode) if !isNillLiteral(iter) => FoldRes(item, iter, mode).leaf
+    case ForModel(item, iter, mode) if !isNillLiteral(iter) =>
+      val modeRes = mode match {
+        case ForModel.Mode.Null => FoldRes.Mode.Null
+        case ForModel.Mode.Never => FoldRes.Mode.Never
+      }
+
+      FoldRes(item, iter, modeRes).leaf
     case RestrictionModel(item, itemType) => RestrictionRes(item, itemType).leaf
     case DetachModel => ParRes.leaf
     case ParModel => ParRes.leaf

--- a/model/res/src/main/scala/aqua/res/ResolvedOp.scala
+++ b/model/res/src/main/scala/aqua/res/ResolvedOp.scala
@@ -32,9 +32,18 @@ case class MatchMismatchRes(left: ValueModel, right: ValueModel, shouldMatch: Bo
   override def toString: String = s"(${if (shouldMatch) "match" else "mismatch"} $left $right)"
 }
 
-case class FoldRes(item: String, iterable: ValueModel, mode: Option[ForModel.Mode] = None)
-    extends ResolvedOp {
-  override def toString: String = s"(fold $iterable $item ${mode.map(_.toString).getOrElse("")}"
+case class FoldRes(item: String, iterable: ValueModel, mode: FoldRes.Mode) extends ResolvedOp {
+  override def toString: String = s"(fold $iterable $item ${mode.toString.toLowerCase()}"
+}
+
+object FoldRes {
+  enum Mode { case Null, Never }
+
+  def lastNull(item: String, iterable: ValueModel): FoldRes =
+    FoldRes(item, iterable, Mode.Null)
+
+  def lastNever(item: String, iterable: ValueModel): FoldRes =
+    FoldRes(item, iterable, Mode.Never)
 }
 
 case class RestrictionRes(item: String, `type`: DataType) extends ResolvedOp {
@@ -50,7 +59,8 @@ case class CallServiceRes(
   override def toString: String = s"(call $peerId ($serviceId $funcName) $call)"
 }
 
-case class ApStreamMapRes(key: ValueModel, value: ValueModel, exportTo: CallModel.Export) extends ResolvedOp {
+case class ApStreamMapRes(key: ValueModel, value: ValueModel, exportTo: CallModel.Export)
+    extends ResolvedOp {
   override def toString: String = s"(ap ($key $value) $exportTo)"
 }
 

--- a/model/res/src/test/scala/aqua/res/ResBuilder.scala
+++ b/model/res/src/test/scala/aqua/res/ResBuilder.scala
@@ -18,7 +18,7 @@ object ResBuilder {
     val arrayRes = VarModel(stream.name + "_gate", ArrayType(ScalarType.string))
 
     RestrictionRes(testVM.name, testStreamType).wrap(
-      FoldRes(iter.name, stream, ForModel.Mode.Never.some).wrap(
+      FoldRes(iter.name, stream, FoldRes.Mode.Never).wrap(
         ApRes(iter, CallModel.Export(testVM.name, testVM.`type`)).leaf,
         CanonRes(testVM, peer, CallModel.Export(canon.name, canon.`type`)).leaf,
         XorRes.wrap(

--- a/model/src/main/scala/aqua/model/OpModel.scala
+++ b/model/src/main/scala/aqua/model/OpModel.scala
@@ -147,11 +147,11 @@ case class MatchMismatchModel(left: ValueModel, right: ValueModel, shouldMatch: 
 case class ForModel(
   item: String,
   iterable: ValueModel,
-  mode: Option[ForModel.Mode] = Some(ForModel.Mode.Null)
+  mode: ForModel.Mode = ForModel.Mode.Null
 ) extends SeqGroupModel {
 
   override def toString: String =
-    s"for $item <- $iterable${mode.map(m => " " + m.toString).getOrElse("")}"
+    s"for $item <- $iterable${mode.toString}"
 
   override def restrictsVarNames: Set[String] = Set(item)
 
@@ -175,7 +175,12 @@ case class DeclareStreamModel(value: ValueModel) extends NoExecModel {
 }
 
 // key must be only string or number
-case class InsertKeyValueModel(key: ValueModel, value: ValueModel, assignTo: String, assignToType: StreamMapType) extends OpModel {
+case class InsertKeyValueModel(
+  key: ValueModel,
+  value: ValueModel,
+  assignTo: String,
+  assignToType: StreamMapType
+) extends OpModel {
   override def usesVarNames: Set[String] = value.usesVarNames
 
   override def exportsVarNames: Set[String] = Set(assignTo)

--- a/model/src/main/scala/aqua/model/OpModel.scala
+++ b/model/src/main/scala/aqua/model/OpModel.scala
@@ -165,6 +165,12 @@ object ForModel {
     case Null
     case Never
   }
+
+  def neverMode(item: String, iterable: ValueModel): ForModel =
+    ForModel(item, iterable, Mode.Never)
+
+  def nullMode(item: String, iterable: ValueModel): ForModel =
+    ForModel(item, iterable, Mode.Null)
 }
 
 // TODO how is it used? remove, if it's not

--- a/model/transform/src/main/scala/aqua/model/transform/pre/ArgsProvider.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/pre/ArgsProvider.scala
@@ -35,12 +35,14 @@ case class ArgsFromService(dataServiceId: ValueRaw) extends ArgsProvider {
           Call(Nil, Call.Export(iter, ArrayType(t.element)) :: Nil)
         )
         .leaf,
-      ForTag(item, VarRaw(iter, ArrayType(t.element))).wrap(
-        SeqTag.wrap(
-          PushToStreamTag(VarRaw(item, t.element), Call.Export(varName, t)).leaf,
-          NextTag(item).leaf
+      ForTag
+        .nonBlocking(item, VarRaw(iter, ArrayType(t.element)))
+        .wrap(
+          SeqTag.wrap(
+            PushToStreamTag(VarRaw(item, t.element), Call.Export(varName, t)).leaf,
+            NextTag(item).leaf
+          )
         )
-      )
     )
   }
 

--- a/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/topology/Topology.scala
@@ -377,7 +377,11 @@ object Topology extends Logging {
           NextRes(itemName).leaf
         )
 
-        FoldRes(itemName, v).wrap(if (reversed) steps.reverse else steps)
+        FoldRes
+          .lastNull(itemName, v)
+          .wrap(
+            if (reversed) steps.reverse else steps
+          )
       case _ =>
         MakeRes.hop(v)
     }

--- a/model/transform/src/test/scala/aqua/model/transform/ModelBuilder.scala
+++ b/model/transform/src/test/scala/aqua/model/transform/ModelBuilder.scala
@@ -132,7 +132,8 @@ object ModelBuilder {
   def foldPar(item: String, iter: ValueRaw, body: OpModel.Tree*) = {
     val ops = SeqModel.wrap(body: _*)
     DetachModel.wrap(
-      ForModel(item, ValueModel.fromRaw(iter), ForModel.Mode.Never)
+      ForModel
+        .neverMode(item, ValueModel.fromRaw(iter))
         .wrap(ParModel.wrap(ops, NextModel(item).leaf))
     )
   }

--- a/model/transform/src/test/scala/aqua/model/transform/ModelBuilder.scala
+++ b/model/transform/src/test/scala/aqua/model/transform/ModelBuilder.scala
@@ -124,7 +124,7 @@ object ModelBuilder {
         failErrorModel
       )
 
-  def fold(item: String, iter: ValueRaw, mode: Option[ForModel.Mode], body: OpModel.Tree*) = {
+  def fold(item: String, iter: ValueRaw, mode: ForModel.Mode, body: OpModel.Tree*) = {
     val ops = SeqModel.wrap(body: _*)
     ForModel(item, ValueModel.fromRaw(iter), mode).wrap(ops, NextModel(item).leaf)
   }
@@ -132,7 +132,7 @@ object ModelBuilder {
   def foldPar(item: String, iter: ValueRaw, body: OpModel.Tree*) = {
     val ops = SeqModel.wrap(body: _*)
     DetachModel.wrap(
-      ForModel(item, ValueModel.fromRaw(iter), ForModel.Mode.Never.some)
+      ForModel(item, ValueModel.fromRaw(iter), ForModel.Mode.Never)
         .wrap(ParModel.wrap(ops, NextModel(item).leaf))
     )
   }

--- a/model/transform/src/test/scala/aqua/model/transform/topology/OpModelTreeCursorSpec.scala
+++ b/model/transform/src/test/scala/aqua/model/transform/topology/OpModelTreeCursorSpec.scala
@@ -1,7 +1,7 @@
 package aqua.model.transform.topology
 
 import aqua.model.transform.ModelBuilder
-import aqua.model.{CallModel, OnModel, SeqModel}
+import aqua.model.{CallModel, ForModel, OnModel, SeqModel}
 import aqua.model.transform.cursor.ChainZipper
 import aqua.raw.value.{LiteralRaw, ValueRaw, VarRaw}
 import aqua.raw.ops.{Call, FuncOp, OnTag}
@@ -137,7 +137,7 @@ class OpModelTreeCursorSpec extends AnyFlatSpec with Matchers {
                 fold(
                   "item",
                   VarRaw("iterable", ArrayType(ScalarType.string)),
-                  None,
+                  ForModel.Mode.Null,
                   OnModel(
                     VarRaw("-in-fold-", ScalarType.string),
                     Chain.one(VarRaw("-fold-relay-", ScalarType.string))

--- a/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
@@ -581,7 +581,7 @@ class SemanticsSpec extends AnyFlatSpec with Matchers with Inside {
                          |""".stripMargin
 
     insideBody(script) { body =>
-      matchSubtree(body) { case (ForTag("p", _, None), forTag) =>
+      matchSubtree(body) { case (ForTag("p", _, ForTag.Mode.Blocking), forTag) =>
         matchChildren(forTag) { case (ParTag, parTag) =>
           matchChildren(parTag)(
             { case (OnTag(_, _, strat), _) =>


### PR DESCRIPTION
## Description
Always generate `last` argument of `fold` instruction in result AIR to make this explicit.

## Proposed Changes
Removal of `Option` for `for` and `fold` models

## Implementation Details
Self-descriptive

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] ~~Proposed changes are covered by tests.~~ No tests applicable
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

