### PR TITLE
fix(compiler): Restrict assignment of 'nil' and empty array to variable [LNG-246]

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -62,9 +62,9 @@ runner {
   }
 }
 
-rewrite {
-  rules = [
-    SortImports
-  ]
-}
+rewrite.rules = [Imports]
+rewrite.imports.sort = ascii
+rewrite.imports.groups = [
+  ["aqua\\..*"]
+]
 #runner.dialect = scala3

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,3 +1,3 @@
 func z() -> string:
-    arr = nil
+    arr = []
     <- arr!

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,6 +1,3 @@
-alias Troll: u32
-
-func test() -> i8:
-  MyAbility = Troll(f = "sf")
-
-  <- 42
+func z() -> string:
+    arr = nil
+    <- arr!

--- a/model/inline/src/main/scala/aqua/model/inline/raw/ApplyPropertiesRawInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/raw/ApplyPropertiesRawInliner.scala
@@ -343,7 +343,7 @@ object ApplyPropertiesRawInliner extends RawInliner[ApplyPropertyRaw] with Loggi
             Some(IntoIndexRaw(idx, _), otherProperties)
           ) =>
         unfold(vr).flatMap {
-          case (VarModel(nameVM, _, _), inl) =>
+          case (VarModel(nameVM, _, _), _) =>
             for {
               gateInlined <- unfoldStreamGate(nameVM, st, idx)
               (gateVM, gateInline) = gateInlined

--- a/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
@@ -34,7 +34,6 @@ object ValueRaw {
   val ParticleTimestamp: LiteralRaw = LiteralRaw("%timestamp%", ScalarType.u64)
 
   val Nil: LiteralRaw = LiteralRaw("[]", StreamType(BottomType))
-  val VarNil: VarRaw = VarRaw("nil", StreamType(BottomType))
 
   /**
    * Type of error value

--- a/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/value/ValueRaw.scala
@@ -34,6 +34,7 @@ object ValueRaw {
   val ParticleTimestamp: LiteralRaw = LiteralRaw("%timestamp%", ScalarType.u64)
 
   val Nil: LiteralRaw = LiteralRaw("[]", StreamType(BottomType))
+  val VarNil: VarRaw = VarRaw("nil", StreamType(BottomType))
 
   /**
    * Type of error value

--- a/parser/src/main/scala/aqua/parser/ParserError.scala
+++ b/parser/src/main/scala/aqua/parser/ParserError.scala
@@ -42,12 +42,12 @@ object ParserError {
       case WithContext(str, exp: WithContext) => expectationToString(exp, List(str))
       case WithContext(str, exp) => s"$str (${expectationToString(exp)})" +: acc
       case FailWith(_, message) => message +: acc
-      case InRange(offset, lower, upper) =>
+      case InRange(_, lower, upper) =>
         if (lower == upper)
           s"Expected symbol '${betterSymbol(lower)}'" +: acc
         else
           s"Expected symbols from '${betterSymbol(lower)}' to '${betterSymbol(upper)}'" +: acc
-      case OneOfStr(offset, strs) =>
+      case OneOfStr(_, strs) =>
         s"Expected one of these strings: ${strs.map(s => s"'$s'").mkString(", ")}" +: acc
       case e => ("Expected: " + e.toString) +: acc
     }

--- a/parser/src/main/scala/aqua/parser/expr/func/AssignmentExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/func/AssignmentExpr.scala
@@ -20,16 +20,7 @@ case class AssignmentExpr[F[_]](
 object AssignmentExpr extends Expr.Leaf {
 
   override val p: P[AssignmentExpr[Span.S]] =
-    ((Name.variable <* ` = `).with1 ~ ValueToken.`value`).flatMap { case (variable, value) =>
-      value match {
-        case CollectionToken(_, values) =>
-          if (values.isEmpty)
-            P.failWith(
-              "Assigning empty array to a variable is prohibited. You can create an array with values (like '[a, b, c]') or use '[]' in place."
-            )
-          else P.pure(AssignmentExpr(variable, value))
-        case _ =>
-          P.pure(AssignmentExpr(variable, value))
-      }
+    ((Name.variable <* ` = `).with1 ~ ValueToken.`value`).map { case (variable, value) =>
+      AssignmentExpr(variable, value)
     }
 }

--- a/semantics/src/main/scala/aqua/semantics/expr/ArrowTypeSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ArrowTypeSem.scala
@@ -3,19 +3,17 @@ package aqua.semantics.expr
 import aqua.parser.expr.ArrowTypeExpr
 import aqua.raw.{Raw, TypeRaw}
 import aqua.semantics.Prog
-import aqua.semantics.rules.abilities.AbilitiesAlgebra
 import aqua.semantics.rules.definitions.DefinitionsAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
-import cats.syntax.functor.*
+import cats.Monad
 import cats.syntax.applicative.*
 import cats.syntax.flatMap.*
-import cats.Monad
+import cats.syntax.functor.*
 
 class ArrowTypeSem[S[_]](val expr: ArrowTypeExpr[S]) extends AnyVal {
 
   def program[Alg[_]: Monad](implicit
     T: TypesAlgebra[S, Alg],
-    A: AbilitiesAlgebra[S, Alg],
     D: DefinitionsAlgebra[S, Alg]
   ): Prog[Alg, Raw] =
     T.resolveArrowDef(expr.`type`).flatMap {

--- a/semantics/src/main/scala/aqua/semantics/expr/ArrowTypeSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ArrowTypeSem.scala
@@ -5,6 +5,7 @@ import aqua.raw.{Raw, TypeRaw}
 import aqua.semantics.Prog
 import aqua.semantics.rules.definitions.DefinitionsAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
+
 import cats.Monad
 import cats.syntax.applicative.*
 import cats.syntax.flatMap.*

--- a/semantics/src/main/scala/aqua/semantics/expr/func/AssignmentSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/AssignmentSem.scala
@@ -1,11 +1,9 @@
 package aqua.semantics.expr.func
 
-import aqua.raw.Raw
-import aqua.types.ArrowType
-import aqua.raw.value.CallArrowRaw
-import aqua.raw.ops.AssignmentTag
 import aqua.parser.expr.func.AssignmentExpr
-import aqua.raw.arrow.FuncRaw
+import aqua.raw.Raw
+import aqua.raw.ops.AssignmentTag
+import aqua.raw.value.ValueRaw
 import aqua.semantics.Prog
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
@@ -22,18 +20,10 @@ class AssignmentSem[S[_]](val expr: AssignmentExpr[S]) extends AnyVal {
   ): Prog[Alg, Raw] =
     V.valueToRaw(expr.value).flatMap {
       case Some(vm) =>
-        vm.`type` match {
-          case at @ ArrowType(_, _) =>
-            N.defineArrow(expr.variable, at, false) as (AssignmentTag(
-              vm,
-              expr.variable.value
-            ).funcOpLeaf: Raw)
-          case _ =>
-            N.derive(expr.variable, vm.`type`, vm.varNames) as (AssignmentTag(
-              vm,
-              expr.variable.value
-            ).funcOpLeaf: Raw)
-        }
+        N.assign(expr.variable, vm) as (AssignmentTag(
+          vm,
+          expr.variable.value
+        ).funcOpLeaf: Raw)
 
       case _ => Raw.error("Cannot resolve assignment type").pure[Alg]
     }

--- a/semantics/src/main/scala/aqua/semantics/expr/func/AssignmentSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/AssignmentSem.scala
@@ -7,6 +7,7 @@ import aqua.raw.value.ValueRaw
 import aqua.semantics.Prog
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
+
 import cats.Monad
 import cats.syntax.applicative.*
 import cats.syntax.flatMap.*

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -78,6 +78,9 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
       case l @ LiteralToken(_, t) =>
         LiteralRaw(l.value, t).some.pure[Alg]
 
+      case VarToken(name) if name.value == ValueRaw.Nil.value =>
+        ValueRaw.Nil.some.pure[Alg]
+
       case VarToken(name) =>
         N.read(name, mustBeDefined = false).flatMap {
           case Some(t) =>

--- a/semantics/src/main/scala/aqua/semantics/rules/names/NamesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/names/NamesAlgebra.scala
@@ -1,8 +1,8 @@
 package aqua.semantics.rules.names
 
-import aqua.parser.lexer.{LiteralToken, Name, Token, ValueToken}
+import aqua.parser.lexer.{Name, Token}
+import aqua.raw.value.ValueRaw
 import aqua.types.{ArrowType, StreamType, Type}
-import cats.InjectK
 
 trait NamesAlgebra[S[_], Alg[_]] {
 
@@ -21,6 +21,8 @@ trait NamesAlgebra[S[_], Alg[_]] {
 
   def defineConstant(name: Name[S], `type`: Type): Alg[Boolean]
 
+  def assign(name: Name[S], value: ValueRaw): Alg[Boolean]
+  
   def defineArrow(name: Name[S], gen: ArrowType, isRoot: Boolean): Alg[Boolean]
 
   def streamsDefinedWithinScope(): Alg[Map[String, StreamType]]

--- a/semantics/src/main/scala/aqua/semantics/rules/names/NamesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/names/NamesInterpreter.scala
@@ -134,7 +134,7 @@ class NamesInterpreter[S[_], X](using
 
   override def assign(name: Name[S], value: ValueRaw): SX[Boolean] =
     value match {
-      case ValueRaw.Nil | ValueRaw.VarNil =>
+      case ValueRaw.Nil =>
         report
           .error(
             name,

--- a/semantics/src/test/scala/aqua/semantics/ArrowSemSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/ArrowSemSpec.scala
@@ -1,7 +1,7 @@
 package aqua.semantics
 
 import aqua.parser.expr.func.ArrowExpr
-import aqua.parser.lexer.{BasicTypeToken, Name}
+import aqua.parser.lexer.BasicTypeToken
 import aqua.raw.Raw
 import aqua.raw.arrow.ArrowRaw
 import aqua.raw.ops.*
@@ -12,20 +12,17 @@ import aqua.types.*
 import aqua.types.ScalarType.*
 
 import cats.Id
-import cats.syntax.applicative.*
 import cats.data.{NonEmptyList, NonEmptyMap, State}
-import org.scalatest.EitherValues
+import cats.syntax.applicative.*
+import org.scalatest.{EitherValues, Inside}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.Inside
 
 class ArrowSemSpec extends AnyFlatSpec with Matchers with EitherValues with Inside {
 
-  import Utils.{given, *}
+  import Utils.{*, given}
 
   def program(arrowStr: String): Prog[State[CompilerState[cats.Id], *], Raw] = {
-    import CompilerState.*
-
     val expr = ArrowExpr.p.parseAll(arrowStr).value.mapK(spanToId)
     val sem = new ArrowSem[Id](expr)
 

--- a/semantics/src/test/scala/aqua/semantics/AssignmentSemSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/AssignmentSemSpec.scala
@@ -1,0 +1,48 @@
+package aqua.semantics
+
+import aqua.parser.expr.func.{AssignmentExpr, ClosureExpr}
+import aqua.parser.lexer.CollectionToken.Mode.ArrayMode
+import aqua.parser.lexer.{CollectionToken, Name, VarToken}
+import aqua.parser.lift.Span
+import aqua.raw.Raw
+import aqua.semantics.expr.func.{AssignmentSem, ClosureSem}
+
+import cats.Id
+import cats.data.State
+import org.scalatest.Inside
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AssignmentSemSpec extends AnyFlatSpec with Matchers with Inside {
+
+  import Utils.{*, given}
+
+  val program: Prog[State[CompilerState[cats.Id], *], Raw] = {
+    val expr = ClosureExpr(Name[Id]("closure"), None)
+    val sem = new ClosureSem[Id](expr)
+
+    sem.program[State[CompilerState[Id], *]]
+  }
+
+  "it" should "throw an error on 'nil'" in {
+    val expr = AssignmentExpr(Name[Id]("emptyArr"), VarToken[Id](Name[Id]("nil")))
+    val sem = new AssignmentSem[Id](expr)
+
+    val state = getState(sem.program[State[CompilerState[Id], *]])
+
+    inside(state.errors) { errors =>
+      atLeast(1, errors.toList) shouldBe a[RulesViolated[Span.S]]
+    }
+  }
+
+  "it" should "throw an error on empty array" in {
+    val expr = AssignmentExpr(Name[Id]("emptyArr"), CollectionToken[Id](ArrayMode, Nil))
+    val sem = new AssignmentSem[Id](expr)
+
+    val state = getState(sem.program[State[CompilerState[Id], *]])
+
+    inside(state.errors) { errors =>
+      atLeast(1, errors.toList) shouldBe a[RulesViolated[Span.S]]
+    }
+  }
+}

--- a/semantics/src/test/scala/aqua/semantics/AssignmentSemSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/AssignmentSemSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.matchers.should.Matchers
 
 class AssignmentSemSpec extends AnyFlatSpec with Matchers with Inside {
 
-  import Utils.{*, given}
+  import Utils.{given, *}
 
   val program: Prog[State[CompilerState[cats.Id], *], Raw] = {
     val expr = ClosureExpr(Name[Id]("closure"), None)

--- a/semantics/src/test/scala/aqua/semantics/ClosureSemSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/ClosureSemSpec.scala
@@ -1,38 +1,24 @@
 package aqua.semantics
 
 import aqua.parser.expr.func.ClosureExpr
-import aqua.parser.lexer.{Name, Token}
-import aqua.raw.arrow.ArrowRaw
+import aqua.parser.lexer.Name
 import aqua.raw.Raw
-import aqua.raw.ops.{EmptyTag, FuncOp, RawTag}
+import aqua.raw.arrow.ArrowRaw
+import aqua.raw.ops.RawTag
 import aqua.semantics.expr.func.ClosureSem
-import aqua.semantics.rules.names.{NamesInterpreter, NamesState}
 import aqua.types.{ArrowType, ProductType}
+
+import cats.Id
 import cats.data.*
 import cats.data.State.*
-import cats.instances.all.*
-import cats.syntax.all.*
-import cats.syntax.applicative.*
-import cats.syntax.apply.*
-import cats.syntax.bifunctor.*
-import cats.syntax.comonad.*
-import cats.syntax.flatMap.*
-import cats.syntax.functor.*
-import cats.syntax.monad.*
-import cats.syntax.semigroup.*
-import cats.{catsInstancesForId, Id, Monad}
-import monocle.Lens
-import monocle.macros.GenLens
-import monocle.syntax.all.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class ClosureSemSpec extends AnyFlatSpec with Matchers {
 
-  import Utils.{given, *}
+  import Utils.{*, given}
 
   val program: Prog[State[CompilerState[cats.Id], *], Raw] = {
-    import CompilerState.*
     val expr = ClosureExpr(Name[Id]("closure"), None)
     val sem = new ClosureSem[Id](expr)
 

--- a/semantics/src/test/scala/aqua/semantics/HeaderSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/HeaderSpec.scala
@@ -5,14 +5,13 @@ import aqua.parser.lexer.{Ability, Name}
 import aqua.raw.RawContext
 import aqua.raw.arrow.{ArrowRaw, FuncRaw}
 import aqua.raw.ops.RawTag
-import aqua.raw.value.VarRaw
 import aqua.semantics.header.{HeaderHandler, HeaderSem}
-import aqua.types.{AbilityType, ArrowType, NilType, ProductType, ScalarType}
+import aqua.types.*
 
 import cats.data.{Chain, NonEmptyList, NonEmptyMap, Validated}
 import cats.free.Cofree
-import cats.{Eval, Id, Monoid}
 import cats.syntax.applicative.*
+import cats.{Eval, Id, Monoid}
 import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
@@ -1,26 +1,19 @@
 package aqua.semantics
 
-import aqua.raw.RawContext
-import aqua.parser.Ast
-import aqua.raw.ops.{Call, CallArrowRawTag, FuncOp, OnTag, ParTag, RawTag, SeqGroupTag, SeqTag}
-import aqua.parser.Parser
+import aqua.parser.{Ast, Parser}
 import aqua.parser.lift.{LiftParser, Span}
+import aqua.raw.RawContext
+import aqua.raw.ops.*
 import aqua.raw.value.*
 import aqua.types.*
-import aqua.raw.ops.*
 
+import cats.Eval
+import cats.data.{Chain, EitherNec, NonEmptyChain, Validated}
+import cats.free.Cofree
+import cats.syntax.foldable.*
+import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.Inside
-import cats.~>
-import cats.data.{Chain, EitherNec, NonEmptyChain}
-import cats.syntax.show.*
-import cats.syntax.traverse.*
-import cats.syntax.foldable.*
-import cats.data.Validated
-import cats.free.Cofree
-import cats.data.State
-import cats.Eval
 
 class SemanticsSpec extends AnyFlatSpec with Matchers with Inside {
 

--- a/semantics/src/test/scala/aqua/semantics/Utils.scala
+++ b/semantics/src/test/scala/aqua/semantics/Utils.scala
@@ -1,23 +1,17 @@
 package aqua.semantics
 
-import aqua.parser.expr.func.ClosureExpr
-import aqua.parser.lexer.{Name, Token}
 import aqua.parser.lift.Span
 import aqua.raw.{Raw, RawContext}
-import aqua.semantics.expr.func.ClosureSem
-import aqua.semantics.rules.abilities.{AbilitiesAlgebra, AbilitiesInterpreter, AbilitiesState}
+import aqua.semantics.rules.abilities.{AbilitiesAlgebra, AbilitiesInterpreter}
 import aqua.semantics.rules.locations.{DummyLocationsInterpreter, LocationsAlgebra}
-import aqua.semantics.rules.names.{NamesAlgebra, NamesInterpreter, NamesState}
-import aqua.semantics.rules.types.{TypesAlgebra, TypesInterpreter, TypesState}
 import aqua.semantics.rules.mangler.{ManglerAlgebra, ManglerInterpreter}
+import aqua.semantics.rules.names.{NamesAlgebra, NamesInterpreter}
 import aqua.semantics.rules.report.{ReportAlgebra, ReportInterpreter}
+import aqua.semantics.rules.types.{TypesAlgebra, TypesInterpreter}
 import aqua.types.*
 
 import cats.data.State
-import cats.{~>, Id}
-import monocle.Lens
-import monocle.macros.GenLens
-import monocle.syntax.all.*
+import cats.{Id, ~>}
 
 object Utils {
 
@@ -48,6 +42,10 @@ object Utils {
 
   def getModel(prog: Prog[State[CompilerState[cats.Id], *], Raw]): Raw = {
     prog.apply(emptyS).run(blankCS).value._2
+  }
+
+  def getState(prog: Prog[State[CompilerState[cats.Id], *], Raw]): CompilerState[Id] = {
+    prog.apply(emptyS).run(blankCS).value._1
   }
 
   def getState(

--- a/semantics/src/test/scala/aqua/semantics/ValuesAlgebraSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/ValuesAlgebraSpec.scala
@@ -12,6 +12,7 @@ import aqua.semantics.rules.names.{NamesAlgebra, NamesInterpreter, NamesState}
 import aqua.semantics.rules.report.{ReportAlgebra, ReportInterpreter}
 import aqua.semantics.rules.types.{TypesAlgebra, TypesInterpreter}
 import aqua.types.*
+
 import cats.Id
 import cats.data.{NonEmptyList, NonEmptyMap, State}
 import monocle.syntax.all.*


### PR DESCRIPTION
## Description
Because the compiler cannot identify a type of empty array in an assignment, it must throw an error.

## Implementation Details
Move error on '[]' from parser to semantic and add `nil` case

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

