### PR TITLE
fix(compiler): Code generate wrong stream name in AIR [LNG-276]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -7,8 +7,6 @@ func returnNil() -> *string:
   <- someStr
 
 func newFunc() -> []string:
-  -- new stream
-    stream <- returnNil() -- stream -> someStr: *str
+    stream <- returnNil()
     stream <<- "asd"
     <- stream
-  -- end

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,6 +1,14 @@
-alias Troll: u32
+aqua A
 
-func test() -> i8:
-  MyAbility = Troll(f = "sf")
+export newFunc
 
-  <- 42
+func returnNil() -> *string:
+  someStr: *string
+  <- someStr
+
+func newFunc() -> []string:
+  -- new stream
+    stream <- returnNil() -- stream -> someStr: *str
+    stream <<- "asd"
+    <- stream
+  -- end

--- a/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
@@ -317,7 +317,7 @@ object ArrowInliner extends Logging {
     )
     defineRenames <- Mangler[S].findAndForbidNames(defineNames)
 
-    renaming = (
+    renaming =
       data.renames ++
         streamRenames ++
         arrowRenames ++
@@ -325,7 +325,6 @@ object ArrowInliner extends Logging {
         capturedValues.renames ++
         capturedArrows.renames ++
         defineRenames
-    )
 
     /**
      * TODO: Optimize resolve.

--- a/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
+++ b/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
@@ -186,7 +186,7 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
   /**
    * func returnNil() -> *string:
    *   someStr: *string
-   * <- someStr
+   *   <- someStr
    *
    * func newFunc() -> []string:
    *   stream <- returnNil()

--- a/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
+++ b/model/inline/src/test/scala/aqua/model/inline/ArrowInlinerSpec.scala
@@ -184,6 +184,96 @@ class ArrowInlinerSpec extends AnyFlatSpec with Matchers with Inside {
   }
 
   /**
+   * func returnNil() -> *string:
+   *   someStr: *string
+   * <- someStr
+   *
+   * func newFunc() -> []string:
+   *   stream <- returnNil()
+   *   stream <<- "asd"
+   * <- stream
+   */
+  it should "rename restricted stream correctly" in {
+    val streamType = StreamType(ScalarType.string)
+    val someStr = VarRaw("someStr", streamType)
+
+    val returnStreamArrowType = ArrowType(
+      ProductType(Nil),
+      ProductType(streamType :: Nil)
+    )
+
+    val returnNil = FuncArrow(
+      "returnNil",
+      SeqTag.wrap(
+        DeclareStreamTag(someStr).leaf,
+        ReturnTag(
+          NonEmptyList.one(someStr)
+        ).leaf
+      ),
+      returnStreamArrowType,
+      List(someStr),
+      Map.empty,
+      Map.empty,
+      None
+    )
+
+    val streamVar = VarRaw("stream", streamType)
+    val canonStreamVar = VarRaw(
+      s"-${streamVar.name}-canon-0",
+      CanonStreamType(ScalarType.string)
+    )
+    val flatStreamVar = VarRaw(
+      s"-${streamVar.name}-flat-0",
+      ArrayType(ScalarType.string)
+    )
+
+    val newFunc = FuncArrow(
+      "newFunc",
+      RestrictionTag(streamVar.name, streamType).wrap(
+        SeqTag.wrap(
+          CallArrowRawTag
+            .func(
+              returnNil.funcName,
+              Call(Nil, Call.Export(streamVar.name, streamType) :: Nil)
+            )
+            .leaf,
+          PushToStreamTag(
+            LiteralRaw.quote("asd"),
+            Call.Export(streamVar.name, streamVar.`type`)
+          ).leaf,
+          CanonicalizeTag(
+            streamVar,
+            Call.Export(canonStreamVar.name, canonStreamVar.`type`)
+          ).leaf,
+          FlattenTag(
+            canonStreamVar,
+            flatStreamVar.name
+          ).leaf,
+          ReturnTag(
+            NonEmptyList.one(flatStreamVar)
+          ).leaf
+        )
+      ),
+      ArrowType(
+        ProductType(Nil),
+        ProductType(ArrayType(ScalarType.string) :: Nil)
+      ),
+      List(flatStreamVar),
+      Map(returnNil.funcName -> returnNil),
+      Map.empty,
+      None
+    )
+
+    val model = callFuncModel(newFunc)
+
+    val restrictionName = model.collect {
+      case RestrictionModel(name, _) => name
+    }.headOption
+
+    restrictionName shouldBe Some(someStr.name)
+  }
+
+  /**
    * func returnStream() -> *string:
    *    stream: *string
    *    stream <<- "one"

--- a/model/transform/src/main/scala/aqua/model/transform/pre/FuncPreTransformer.scala
+++ b/model/transform/src/main/scala/aqua/model/transform/pre/FuncPreTransformer.scala
@@ -1,12 +1,10 @@
 package aqua.model.transform.pre
 
-import aqua.model.FuncArrow
-import aqua.model.ArgsCall
-import aqua.raw.ops.{Call, CallArrowRawTag, RawTag, SeqTag, TryTag}
-import aqua.raw.value.{ValueRaw, VarRaw}
+import aqua.model.{ArgsCall, FuncArrow}
+import aqua.raw.ops.*
+import aqua.raw.value.VarRaw
 import aqua.types.*
 
-import cats.syntax.show.*
 import cats.syntax.option.*
 
 /**
@@ -47,7 +45,7 @@ case class FuncPreTransformer(
    * @return FuncArrow that can be called and delegates the call to a client-registered callback
    */
   private def arrowToCallback(name: String, arrowType: ArrowType): FuncArrow = {
-    val (args, call, ret) = ArgsCall.arrowToArgsCallRet(arrowType)
+    val (_, call, ret) = ArgsCall.arrowToArgsCallRet(arrowType)
     FuncArrow(
       arrowCallbackPrefix + name,
       callback(name, call),

--- a/semantics/src/main/scala/aqua/semantics/rules/names/NamesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/names/NamesInterpreter.scala
@@ -3,15 +3,15 @@ package aqua.semantics.rules.names
 import aqua.parser.lexer.{Name, Token}
 import aqua.semantics.Levenshtein
 import aqua.semantics.rules.StackInterpreter
-import aqua.semantics.rules.report.ReportAlgebra
 import aqua.semantics.rules.locations.LocationsAlgebra
-import aqua.types.{AbilityType, ArrowType, StreamType, Type}
+import aqua.semantics.rules.report.ReportAlgebra
+import aqua.types.{ArrowType, StreamType, Type}
 
 import cats.data.{OptionT, State}
+import cats.syntax.all.*
+import cats.syntax.applicative.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
-import cats.syntax.applicative.*
-import cats.syntax.all.*
 import monocle.Lens
 import monocle.macros.GenLens
 
@@ -160,7 +160,7 @@ class NamesInterpreter[S[_], X](using
     mapStackHead(Map.empty) { frame =>
       frame -> frame.names.collect { case (n, st @ StreamType(_)) =>
         n -> st
-      }.toMap
+      }
     }
 
   override def beginScope(token: Token[S]): SX[Unit] =


### PR DESCRIPTION
## Description
```
func returnNil() -> *string:
  someStr: *string
  <- someStr

func newFunc():
  ...
  stream <- returnNil() -- here compiler makes a restriction for the stream before calling this arrow
                                   -- should be a mechanism that can inline tag after inlining its children
  ...
  ```

## Proposed Changes
Add `After` for `TagInlined` that will be called after all children inlined.

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

