### PR TITLE
fix(compiler): Incorrect focus on error [LNG-274]

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -62,9 +62,9 @@ runner {
   }
 }
 
-rewrite {
-  rules = [
-    SortImports
-  ]
-}
+rewrite.rules = [Imports]
+rewrite.imports.sort = ascii
+rewrite.imports.groups = [
+  ["aqua\\..*"]
+]
 #runner.dialect = scala3

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,6 +1,2 @@
-alias Troll: u32
-
-func test() -> i8:
-  MyAbility = Troll(f = "sf")
-
-  <- 42
+func arr(strs: []string) -> []string
+  <- strs

--- a/io/src/main/scala/aqua/Rendering.scala
+++ b/io/src/main/scala/aqua/Rendering.scala
@@ -1,17 +1,14 @@
 package aqua
 
-import aqua.compiler.AquaError.{ParserError as AquaParserError, *}
 import aqua.compiler.*
+import aqua.compiler.AquaError.{ParserError as AquaParserError, *}
 import aqua.files.FileModuleId
 import aqua.io.AquaFileError
 import aqua.parser.lift.{FileSpan, Span}
 import aqua.parser.{ArrowReturnError, BlockIndentError, LexerError, ParserError}
 import aqua.semantics.{HeaderError, RulesViolated, SemanticWarning, WrongAST}
 
-import cats.parse.LocationMap
-import cats.parse.Parser.Expectation
-import cats.parse.Parser.Expectation.*
-import cats.{Eval, Show}
+import cats.Show
 
 object Rendering {
 

--- a/io/src/test/scala/aqua/RenderingSpec.scala
+++ b/io/src/test/scala/aqua/RenderingSpec.scala
@@ -1,6 +1,6 @@
 package aqua
 
-import aqua.Rendering.given_Show_AquaError
+import aqua.Rendering.given
 import aqua.compiler.AquaError
 import aqua.files.FileModuleId
 import aqua.io.AquaFileError

--- a/io/src/test/scala/aqua/RenderingSpec.scala
+++ b/io/src/test/scala/aqua/RenderingSpec.scala
@@ -26,13 +26,9 @@ class RenderingSpec extends AnyFlatSpec with Matchers with Inside with Inspector
     val fileSpan = FileSpan("file", Eval.now(LocationMap(script)), Span(8, 9))
 
 
-    // `.show` don't work for some reason
-    val showResult = given_Show_AquaError.show(
-      AquaError.ParserError[FileModuleId, AquaFileError, FileSpan.F](
-        LexerError[FileSpan.F]((fileSpan, error))
-      )
-    )
+    val result: AquaError[FileModuleId, AquaFileError, FileSpan.F] =
+      AquaError.ParserError(LexerError((fileSpan, error)))
 
-    showResult should include("Syntax error: file:1:37")
+    result.show should include("Syntax error: file:1:37")
   }
 }

--- a/io/src/test/scala/aqua/RenderingSpec.scala
+++ b/io/src/test/scala/aqua/RenderingSpec.scala
@@ -11,6 +11,7 @@ import cats.Eval
 import cats.data.NonEmptyList
 import cats.parse.Parser.Expectation.InRange
 import cats.parse.{LocationMap, Parser}
+import cats.syntax.show.*
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inside, Inspectors}

--- a/io/src/test/scala/aqua/RenderingSpec.scala
+++ b/io/src/test/scala/aqua/RenderingSpec.scala
@@ -1,0 +1,38 @@
+package aqua
+
+import aqua.Rendering.given_Show_AquaError
+import aqua.compiler.AquaError
+import aqua.files.FileModuleId
+import aqua.io.AquaFileError
+import aqua.parser.LexerError
+import aqua.parser.lift.{FileSpan, Span}
+
+import cats.Eval
+import cats.data.NonEmptyList
+import cats.parse.Parser.Expectation.InRange
+import cats.parse.{LocationMap, Parser}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{Inside, Inspectors}
+
+class RenderingSpec extends AnyFlatSpec with Matchers with Inside with Inspectors {
+
+  it should "render end of a string properly" in {
+    val script =
+      """func arr(strs: []string) -> []string
+        |  <- strs""".stripMargin
+
+    val error = Parser.Error(8, NonEmptyList.one(InRange(36, ':', ':')))
+    val fileSpan = FileSpan("file", Eval.now(LocationMap(script)), Span(8, 9))
+
+
+    // `.show` don't work for some reason
+    val showResult = given_Show_AquaError.show(
+      AquaError.ParserError[FileModuleId, AquaFileError, FileSpan.F](
+        LexerError[FileSpan.F]((fileSpan, error))
+      )
+    )
+
+    showResult should include("Syntax error: file:1:37")
+  }
+}

--- a/parser/src/main/scala/aqua/parser/Parser.scala
+++ b/parser/src/main/scala/aqua/parser/Parser.scala
@@ -1,21 +1,16 @@
 package aqua.parser
 
-import aqua.parser.Ast.Tree
-import aqua.parser.{Ast, LexerError, ParserError}
 import aqua.parser.expr.RootExpr
 import aqua.parser.head.HeadExpr
-import aqua.parser.lexer.Token
 import aqua.parser.lift.LiftParser.LiftErrorOps
-import aqua.parser.lift.{FileSpan, LiftParser, Span}
+import aqua.parser.lift.Span.S
+import aqua.parser.lift.{LiftParser, Span}
 import cats.data.{Validated, ValidatedNec}
-import cats.parse.{LocationMap, Parser as P, Parser0 as P0}
-import cats.{~>, Comonad, Eval, Id}
+import cats.parse.{Parser as P, Parser0 as P0}
+import cats.{Comonad, ~>}
 
 object Parser extends scribe.Logging {
-
-  import Span.spanLiftParser
-  lazy val spanParser = parserSchema
-  import LiftParser.Implicits.idLiftParser
+  lazy val spanParser: P0[ValidatedNec[ParserError[S], Ast[S]]] = parserSchema
 
   def parserSchema: P0[ValidatedNec[ParserError[Span.S], Ast[Span.S]]] = {
     logger.trace("creating schema...")

--- a/parser/src/main/scala/aqua/parser/Parser.scala
+++ b/parser/src/main/scala/aqua/parser/Parser.scala
@@ -5,6 +5,7 @@ import aqua.parser.head.HeadExpr
 import aqua.parser.lift.LiftParser.LiftErrorOps
 import aqua.parser.lift.Span.S
 import aqua.parser.lift.{LiftParser, Span}
+
 import cats.data.{Validated, ValidatedNec}
 import cats.parse.{Parser as P, Parser0 as P0}
 import cats.{Comonad, ~>}

--- a/parser/src/main/scala/aqua/parser/lift/Span.scala
+++ b/parser/src/main/scala/aqua/parser/lift/Span.scala
@@ -51,11 +51,17 @@ object Span {
     str: String,
     idx: Int,
     len: Int
-  ): FocusedLine = FocusedLine(
-    str.substring(0, idx),
-    str.substring(idx, idx + len),
-    str.substring(idx + len)
-  )
+  ): FocusedLine =
+    val end = idx + len
+    // if we want to point to the place after a string, pad this string with spaces
+    val padded =
+      if (str.length < idx + len) str.padTo(end, ' ')
+      else str
+    FocusedLine(
+      padded.substring(0, idx),
+      padded.substring(idx, end),
+      padded.substring(end)
+    )
 
   final case class NumberedLine[T](
     number: Int,

--- a/parser/src/main/scala/aqua/parser/lift/Span.scala
+++ b/parser/src/main/scala/aqua/parser/lift/Span.scala
@@ -56,7 +56,7 @@ object Span {
     FocusedLine(
       str.slice(0, idx),
       str.slice(idx, end),
-      str.slice(0, end)
+      str.slice(end, str.length)
     )
 
   final case class NumberedLine[T](

--- a/parser/src/main/scala/aqua/parser/lift/Span.scala
+++ b/parser/src/main/scala/aqua/parser/lift/Span.scala
@@ -1,8 +1,7 @@
 package aqua.parser.lift
 
-import cats.data.NonEmptyList
-import cats.parse.{LocationMap, Parser as P, Parser0}
-import cats.{Comonad, Eval}
+import cats.Comonad
+import cats.parse.{LocationMap, Parser0, Parser as P}
 
 import scala.language.implicitConversions
 
@@ -51,13 +50,14 @@ object Span {
     str: String,
     idx: Int,
     len: Int
-  ): FocusedLine =
+  ): FocusedLine = {
     val end = idx + len
     FocusedLine(
       str.slice(0, idx),
       str.slice(idx, end),
       str.slice(end, str.length)
     )
+  }
 
   final case class NumberedLine[T](
     number: Int,

--- a/parser/src/main/scala/aqua/parser/lift/Span.scala
+++ b/parser/src/main/scala/aqua/parser/lift/Span.scala
@@ -53,7 +53,6 @@ object Span {
     len: Int
   ): FocusedLine =
     val end = idx + len
-    // if we want to point to the place after a string, pad this string with spaces
     FocusedLine(
       str.slice(0, idx),
       str.slice(idx, end),

--- a/parser/src/main/scala/aqua/parser/lift/Span.scala
+++ b/parser/src/main/scala/aqua/parser/lift/Span.scala
@@ -54,13 +54,10 @@ object Span {
   ): FocusedLine =
     val end = idx + len
     // if we want to point to the place after a string, pad this string with spaces
-    val padded =
-      if (str.length < idx + len) str.padTo(end, ' ')
-      else str
     FocusedLine(
-      padded.substring(0, idx),
-      padded.substring(idx, end),
-      padded.substring(end)
+      str.slice(0, idx),
+      str.slice(idx, end),
+      str.slice(0, end)
     )
 
   final case class NumberedLine[T](

--- a/parser/src/test/scala/aqua/parser/FuncExprSpec.scala
+++ b/parser/src/test/scala/aqua/parser/FuncExprSpec.scala
@@ -4,28 +4,24 @@ import aqua.AquaSpec
 import aqua.parser.expr.*
 import aqua.parser.expr.func.*
 import aqua.parser.lexer.*
-import aqua.parser.lift.LiftParser.Implicits.idLiftParser
 import aqua.parser.lift.Span
-import aqua.parser.lift.Span.{P0ToSpan, PToSpan}
 import aqua.types.ScalarType.*
 
-import cats.Id
-import cats.data.{Chain, NonEmptyList}
+import cats.{Eval, Id}
 import cats.data.Chain.*
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.{Chain, NonEmptyList}
 import cats.free.Cofree
 import cats.syntax.foldable.*
-import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.{Inside, Inspectors}
 import org.scalatest.matchers.should.Matchers
-import cats.~>
-import cats.Eval
+import org.scalatest.{Inside, Inspectors}
 
 import scala.collection.mutable
 import scala.language.implicitConversions
 
 class FuncExprSpec extends AnyFlatSpec with Matchers with Inside with Inspectors with AquaSpec {
-  import AquaSpec.{given, *}
+  import AquaSpec.{*, given}
 
   private val parser = Parser.spanParser
 


### PR DESCRIPTION
## Description
```
func arr(strs: []string) -> []string
  <- strs
```
this code throws `StringOutOfBound` instead of parser error 

## Proposed Changes
Pad strings that the compiler error renderer can point.

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

