### PR TITLE
feat(api): Use `js.UndefOr` for `defaultServiceId`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,7 @@ jobs:
       aqua-snapshots: "${{ needs.aqua.outputs.aqua-snapshots }}"
       ref: use-js-client-0.5.0
 
+
   registry:
     needs:
       - fcli-snapshot

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,7 @@ jobs:
     uses: fluencelabs/fluence-cli/.github/workflows/tests.yml@use-js-client-0.5.0
     with:
       aqua-snapshots: "${{ needs.aqua.outputs.aqua-snapshots }}"
+      ref: use-js-client-0.5.0
 
   registry:
     needs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
 
   flox:
     needs: aqua
-    uses: fluencelabs/fluence-cli/.github/workflows/tests.yml@main
+    uses: fluencelabs/fluence-cli/.github/workflows/tests.yml@use-js-client-0.5.0
     with:
       aqua-snapshots: "${{ needs.aqua.outputs.aqua-snapshots }}"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,6 @@ jobs:
       aqua-snapshots: "${{ needs.aqua.outputs.aqua-snapshots }}"
       ref: use-js-client-0.5.0
 
-
   registry:
     needs:
       - fcli-snapshot

--- a/js/js-exports/src/main/scala/aqua/js/Definitions.scala
+++ b/js/js-exports/src/main/scala/aqua/js/Definitions.scala
@@ -115,14 +115,17 @@ object TypeDefinitionJs {
 
 @JSExportAll
 case class ServiceDefJs(
-  defaultServiceId: Option[String],
+  defaultServiceId: js.UndefOr[String],
   functions: LabeledTypeDefJs
 )
 
 object ServiceDefJs {
 
   def apply(sd: ServiceDef): ServiceDefJs = {
-    ServiceDefJs(sd.defaultServiceId, LabeledTypeDefJs(sd.functions))
+    ServiceDefJs(
+      sd.defaultServiceId.getOrElse(()),
+      LabeledTypeDefJs(sd.functions)
+    )
   }
 }
 


### PR DESCRIPTION
## Description
Use `js.UndefOr` for `defaultServiceId` for easy of use in ts.

## Checklist
- [ ] Corresponding issue has been created and linked in PR title.
- [ ] Proposed changes are covered by tests.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

