### PR TITLE
fix(e2e): Use `main` branch for `fcli`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,10 +44,9 @@ jobs:
 
   fcli:
     needs: aqua
-    uses: fluencelabs/fluence-cli/.github/workflows/tests.yml@use-js-client-0.5.0
+    uses: fluencelabs/cli/.github/workflows/tests.yml@main
     with:
       aqua-snapshots: "${{ needs.aqua.outputs.aqua-snapshots }}"
-      ref: use-js-client-0.5.0
 
   registry:
     needs:


### PR DESCRIPTION
## Description
Use `main` branch for `fcli` in e2e github workflow

