### PR TITLE
fix(compiler): Add outside context to closures [LNG-317]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,23 +1,40 @@
 aqua M
 
-export bugLng314
+export bugLng317
+
+service MyOp("op"):
+  identity(s: string) -> string
 
 ability WorkerJob:
-  runOnSingleWorker(w: string) -> string
+  runOnSingleWorker(w: string) -> []string
 
-func disjoint_run{WorkerJob}() -> -> string:
-  run = func () -> string:
-      r <- WorkerJob.runOnSingleWorker()
+func runJob(j: -> []string) -> []string:
+  <- j()
+
+func disjoint_run{WorkerJob}() -> -> []string:
+  run = func () -> []string:
+      r <- WorkerJob.runOnSingleWorker("a")
       <- r
   <- run
 
-func runJob(j: -> string) -> string:
-  <- j()
+func empty() -> string:
+  a = "empty"
+  <- a
 
-func bugLng314() -> string:
-   job2 = () -> string:
-     <- "strstrstr"
-   worker_job = WorkerJob(runOnSingleWorker = job2)
+func bugLng317() -> []string:
+
+   res: *string
+
+   outer = () -> string:
+     <- empty()
+
+   clos = () -> -> []string:
+     job2 = () -> []string:
+       res <- outer()
+       res <- MyOp.identity("identity")
+       <- res
+     <- job2
+   worker_job = WorkerJob(runOnSingleWorker = clos())
    subnet_job <- disjoint_run{worker_job}()
-   res <- runJob(subnet_job)
-   <- res
+   finalRes <- runJob(subnet_job)
+   <- finalRes

--- a/integration-tests/aqua/examples/closures.aqua
+++ b/integration-tests/aqua/examples/closures.aqua
@@ -82,9 +82,6 @@ func multipleClosuresBugLNG262() -> i8, i8:
     arr2 <- create(2)
     <- arr1(), arr2()
 
-service MyOp("op"):
-  identity(s: string) -> string
-
 ability WorkerJob:
   runOnSingleWorker(w: string) -> []string
 

--- a/integration-tests/aqua/examples/closures.aqua
+++ b/integration-tests/aqua/examples/closures.aqua
@@ -2,7 +2,7 @@ module Closure declares *
 
 import "@fluencelabs/aqua-lib/builtin.aqua"
 
-export LocalSrv, closureIn, closureOut, closureBig, closureOut2, lng58Bug, multipleClosuresBugLNG262
+export LocalSrv, closureIn, closureOut, closureBig, closureOut2, lng58Bug, multipleClosuresBugLNG262, lng317Bug
 
 service MyOp("op"):
   identity(s: string) -> string
@@ -81,3 +81,40 @@ func multipleClosuresBugLNG262() -> i8, i8:
     arr1 <- create(1)
     arr2 <- create(2)
     <- arr1(), arr2()
+
+service MyOp("op"):
+  identity(s: string) -> string
+
+ability WorkerJob:
+  runOnSingleWorker(w: string) -> []string
+
+func runJob(j: -> []string) -> []string:
+  <- j()
+
+func disjoint_run{WorkerJob}() -> -> []string:
+  run = func () -> []string:
+      r <- WorkerJob.runOnSingleWorker("a")
+      <- r
+  <- run
+
+func empty() -> string:
+  a = "empty"
+  <- a
+
+func lng317Bug() -> []string:
+
+   res: *string
+
+   outer = () -> string:
+     <- empty()
+
+   clos = () -> -> []string:
+     job2 = () -> []string:
+       res <- outer()
+       res <- MyOp.identity("identity")
+       <- res
+     <- job2
+   worker_job = WorkerJob(runOnSingleWorker = clos())
+   subnet_job <- disjoint_run{worker_job}()
+   finalRes <- runJob(subnet_job)
+   <- finalRes

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -123,6 +123,7 @@ import { lng193BugCall } from "../examples/closureReturnRename.js";
 import {
   closuresCall,
   multipleClosuresLNG262BugCall,
+  lng317BugCall
 } from "../examples/closures.js";
 import { closureArrowCaptureCall } from "../examples/closureArrowCapture.js";
 import {
@@ -1110,6 +1111,11 @@ describe("Testing examples", () => {
   it("closures.aqua bug LNG-262", async () => {
     let result = await multipleClosuresLNG262BugCall();
     expect(result).toEqual([1, 2]);
+  });
+
+  it("closures.aqua bug LNG-317", async () => {
+      let result = await lng317BugCall();
+      expect(result).toEqual(["empty", "identity"]);
   });
 
   it("closureArrowCapture.aqua", async () => {

--- a/integration-tests/src/examples/closures.ts
+++ b/integration-tests/src/examples/closures.ts
@@ -5,6 +5,7 @@ import {
   registerLocalSrv,
   closureOut2,
   lng58Bug,
+  lng317Bug,
   multipleClosuresBugLNG262
 } from "../compiled/examples/closures.js";
 import { config } from "../config.js";
@@ -36,4 +37,8 @@ export async function lng58CBugCall(): Promise<string> {
 
 export async function multipleClosuresLNG262BugCall(): Promise<[number, number]> {
   return multipleClosuresBugLNG262();
+}
+
+export async function lng317BugCall(): Promise<string[]> {
+  return lng317Bug();
 }

--- a/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/ArrowInliner.scala
@@ -348,7 +348,7 @@ object ArrowInliner extends Logging {
 
       // Rename arrows according to values
       arrowsRenamed = Renamed(
-        valuesRenamed.renames.filterKeys(abilitiesArrows.keySet).toMap,
+        valuesRenamed.renames.view.filterKeys(abilitiesArrows.keySet).toMap,
         abilitiesArrows.renamed(valuesRenamed.renames)
       )
 

--- a/model/raw/src/main/scala/aqua/raw/arrow/FuncRaw.scala
+++ b/model/raw/src/main/scala/aqua/raw/arrow/FuncRaw.scala
@@ -11,7 +11,7 @@ case class FuncRaw(
 
   override def rawPartType: Type = arrow.`type`
 
-  def capturedVars: Set[String] = {
+  lazy val capturedVars: Set[String] = {
     val freeBodyVars = arrow.body.usesVarNames.value
     val argsNames = arrow.`type`.domain
       .toLabelledList()

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -299,8 +299,7 @@ case class ClosureTag(
 
   override def exportsVarNames: Set[String] = Set(func.name)
 
-  // FIXME: Is it correct?
-  override def usesVarNames: Set[String] = Set.empty
+  override def usesVarNames: Set[String] = func.capturedVars
 
   override def renameExports(map: Map[String, String]): RawTag =
     copy(func =


### PR DESCRIPTION
## Description
Nested closures cannot find arrows on inline step

## Proposed Changes
Add correct context to closures. 

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

