### PR TITLE
fix(compiler): Streams in closures generates wrong AIR

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -2,6 +2,22 @@ aqua A
 
 export haveFun
 
+-- ability SSS:
+--     arrow(x: i8) -> bool
+--
+-- ability CCCC:
+--     arrow(x: i8) -> bool
+--     simple: SSS
+--
+-- func checkAbCalls(a: i8) -> bool, bool, bool:
+--     closure = (x: i8) -> bool:
+--         <- x > 20
+--     MySSS = SSS(arrow = closure)
+--     MyCCCC = CCCC(simple = MySSS, arrow = MySSS.arrow)
+--     res1 <- MySSS.arrow(42)
+--     res2 = MyCCCC.arrow(a)
+--     <- res1, res2, MySSS.arrow(25)
+
 service Dummy("dummy"):
     greeting(s: string) -> string
 
@@ -12,7 +28,7 @@ func disrun(getJob: -> Job) -> Job:
    j <- getJob()
    <- j
 
-func haveFun() -> string:
+func firstStream() -> string:
    brokenStream: *string
 
    job = () -> Job:
@@ -23,5 +39,24 @@ func haveFun() -> string:
      <- Job(run = run)
 
    subnetJob <- disrun(job)
-   subnetJob.run("string for dummy")
+   subnetJob.run("firstStream string")
    <- brokenStream!
+
+func secondStream() -> string:
+   brokenStream: *string
+
+   secondJob = () -> Job:
+     secondRun = (str: string) -> string:
+       brokenStream <- Dummy.greeting(str)
+       <- "run"
+
+     <- Job(run = secondRun)
+
+   subnetJob <- disrun(secondJob)
+   subnetJob.run("secondStream string")
+   <- brokenStream!
+
+func haveFun() -> string, string:
+  res1 <- firstStream()
+  res2 <- secondStream()
+  <- res1, res2

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,33 +1,27 @@
-aqua M
+aqua A
 
-export returnSrvAsAbility
+export haveFun
 
-ability MyAb:
-    call() -> string
+service Dummy("dummy"):
+    greeting(s: string) -> string
 
-service MySrv("default-id"):
-    call() -> string
+ability Job:
+    run(s: string) -> string
 
-func mySrvDefault() -> MyAb:
-    <- MySrv
+func disrun(getJob: -> Job) -> Job:
+   j <- getJob()
+   <- j
 
-func mySrvResolved() -> MyAb:
-    MySrv "resolved-id"
-    <- MySrv
+func haveFun() -> string:
+   brokenStream: *string
 
-func mySrvThird() -> MyAb:
-    MySrv "third-id"
-    <- MySrv
+   job = () -> Job:
+     run = (str: string) -> string:
+       brokenStream <- Dummy.greeting(str)
+       <- "run"
 
-func useMyAb{MyAb}() -> string:
-    <- MyAb.call()
+     <- Job(run = run)
 
-func returnSrvAsAbility() -> []string:
-    result: *string
-    MySrvDefault <- mySrvDefault()
-    MySrvResolved <- mySrvResolved()
-    MySrvThird <- mySrvThird()
-    result <- useMyAb{MySrvDefault}()
-    result <- useMyAb{MySrvResolved}()
-    result <- useMyAb{MySrvThird}()
-    <- result
+   subnetJob <- disrun(job)
+   subnetJob.run("string for dummy")
+   <- brokenStream!

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,9 +1,55 @@
 aqua A
 
-export haveFun
+export get_logs, lng317Bug, lng325Bug, lng325BugTwoFuncs
 
-service Dummy("dummy"):
-    greeting(s: string) -> string
+service Op("op"):
+    id(s1: string)
+    identity(s: string) -> string
+
+service MyOp("op"):
+    id(s1: string)
+    identity(s: string) -> string
+
+func get_logs(a: string):
+    if a == "sdf":
+        error <- Op.identity("some serv")
+        Op.id(error)
+    error: *string
+    error <- Op.identity("stream")
+
+ability WorkerJob:
+  runOnSingleWorker(w: string) -> []string
+
+func runJob(j: -> []string) -> []string:
+  <- j()
+
+func disjoint_run{WorkerJob}() -> -> []string:
+  run = func () -> []string:
+      r <- WorkerJob.runOnSingleWorker("a")
+      <- r
+  <- run
+
+func empty() -> string:
+  a = "empty"
+  <- a
+
+func lng317Bug() -> []string:
+
+   res: *string
+
+   outer = () -> string:
+     <- empty()
+
+   clos = () -> -> []string:
+     job2 = () -> []string:
+       res <- outer()
+       res <- MyOp.identity("identity")
+       <- res
+     <- job2
+   worker_job = WorkerJob(runOnSingleWorker = clos())
+   subnet_job <- disjoint_run{worker_job}()
+   finalRes <- runJob(subnet_job)
+   <- finalRes
 
 ability Job:
     run(s: string) -> string
@@ -12,12 +58,12 @@ func disrun(getJob: -> Job) -> Job:
    j <- getJob()
    <- j
 
-func firstStream() -> string:
+func lng325Bug() -> string:
    brokenStream: *string
 
    job = () -> Job:
      run = (str: string) -> string:
-       brokenStream <- Dummy.greeting(str)
+       brokenStream <- MyOp.identity(str)
        <- "run"
 
      <- Job(run = run)
@@ -31,7 +77,7 @@ func secondStream() -> string:
 
    secondJob = () -> Job:
      secondRun = (str: string) -> string:
-       brokenStream <- Dummy.greeting(str)
+       brokenStream <- MyOp.identity(str)
        <- "run"
 
      <- Job(run = secondRun)
@@ -40,7 +86,7 @@ func secondStream() -> string:
    subnetJob.run("secondStream string")
    <- brokenStream!
 
-func haveFun() -> string, string:
-  res1 <- firstStream()
+func lng325BugTwoFuncs() -> string, string:
+  res1 <- lng325Bug()
   res2 <- secondStream()
   <- res1, res2

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -2,22 +2,6 @@ aqua A
 
 export haveFun
 
--- ability SSS:
---     arrow(x: i8) -> bool
---
--- ability CCCC:
---     arrow(x: i8) -> bool
---     simple: SSS
---
--- func checkAbCalls(a: i8) -> bool, bool, bool:
---     closure = (x: i8) -> bool:
---         <- x > 20
---     MySSS = SSS(arrow = closure)
---     MyCCCC = CCCC(simple = MySSS, arrow = MySSS.arrow)
---     res1 <- MySSS.arrow(42)
---     res2 = MyCCCC.arrow(a)
---     <- res1, res2, MySSS.arrow(25)
-
 service Dummy("dummy"):
     greeting(s: string) -> string
 

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,6 +1,6 @@
 aqua A
 
-export get_logs, lng317Bug, lng325Bug, lng325BugTwoFuncs
+export get_logs
 
 service Op("op"):
     id(s1: string)
@@ -12,81 +12,81 @@ service MyOp("op"):
 
 func get_logs(a: string):
     if a == "sdf":
-        error <- Op.identity("some serv")
-        Op.id(error)
-    error: *string
-    error <- Op.identity("stream")
+        streamA <- Op.identity("some serv")
+        Op.id(streamA)
+    streamA: *string
+    streamA <- Op.identity("stream")
 
-ability WorkerJob:
-  runOnSingleWorker(w: string) -> []string
-
-func runJob(j: -> []string) -> []string:
-  <- j()
-
-func disjoint_run{WorkerJob}() -> -> []string:
-  run = func () -> []string:
-      r <- WorkerJob.runOnSingleWorker("a")
-      <- r
-  <- run
-
-func empty() -> string:
-  a = "empty"
-  <- a
-
-func lng317Bug() -> []string:
-
-   res: *string
-
-   outer = () -> string:
-     <- empty()
-
-   clos = () -> -> []string:
-     job2 = () -> []string:
-       res <- outer()
-       res <- MyOp.identity("identity")
-       <- res
-     <- job2
-   worker_job = WorkerJob(runOnSingleWorker = clos())
-   subnet_job <- disjoint_run{worker_job}()
-   finalRes <- runJob(subnet_job)
-   <- finalRes
-
-ability Job:
-    run(s: string) -> string
-
-func disrun(getJob: -> Job) -> Job:
-   j <- getJob()
-   <- j
-
-func lng325Bug() -> string:
-   brokenStream: *string
-
-   job = () -> Job:
-     run = (str: string) -> string:
-       brokenStream <- MyOp.identity(str)
-       <- "run"
-
-     <- Job(run = run)
-
-   subnetJob <- disrun(job)
-   subnetJob.run("firstStream string")
-   <- brokenStream!
-
-func secondStream() -> string:
-   brokenStream: *string
-
-   secondJob = () -> Job:
-     secondRun = (str: string) -> string:
-       brokenStream <- MyOp.identity(str)
-       <- "run"
-
-     <- Job(run = secondRun)
-
-   subnetJob <- disrun(secondJob)
-   subnetJob.run("secondStream string")
-   <- brokenStream!
-
-func lng325BugTwoFuncs() -> string, string:
-  res1 <- lng325Bug()
-  res2 <- secondStream()
-  <- res1, res2
+-- ability WorkerJob:
+--   runOnSingleWorker(w: string) -> []string
+--
+-- func runJob(j: -> []string) -> []string:
+--   <- j()
+--
+-- func disjoint_run{WorkerJob}() -> -> []string:
+--   run = func () -> []string:
+--       r <- WorkerJob.runOnSingleWorker("a")
+--       <- r
+--   <- run
+--
+-- func empty() -> string:
+--   a = "empty"
+--   <- a
+--
+-- func lng317Bug() -> []string:
+--
+--    res: *string
+--
+--    outer = () -> string:
+--      <- empty()
+--
+--    clos = () -> -> []string:
+--      job2 = () -> []string:
+--        res <- outer()
+--        res <- MyOp.identity("identity")
+--        <- res
+--      <- job2
+--    worker_job = WorkerJob(runOnSingleWorker = clos())
+--    subnet_job <- disjoint_run{worker_job}()
+--    finalRes <- runJob(subnet_job)
+--    <- finalRes
+--
+-- ability Job:
+--     run(s: string) -> string
+--
+-- func disrun(getJob: -> Job) -> Job:
+--    j <- getJob()
+--    <- j
+--
+-- func lng325Bug() -> string:
+--    brokenStream: *string
+--
+--    job = () -> Job:
+--      run = (str: string) -> string:
+--        brokenStream <- MyOp.identity(str)
+--        <- "run"
+--
+--      <- Job(run = run)
+--
+--    subnetJob <- disrun(job)
+--    subnetJob.run("firstStream string")
+--    <- brokenStream!
+--
+-- func secondStream() -> string:
+--    brokenStream: *string
+--
+--    secondJob = () -> Job:
+--      secondRun = (str: string) -> string:
+--        brokenStream <- MyOp.identity(str)
+--        <- "run"
+--
+--      <- Job(run = secondRun)
+--
+--    subnetJob <- disrun(secondJob)
+--    subnetJob.run("secondStream string")
+--    <- brokenStream!
+--
+-- func lng325BugTwoFuncs() -> string, string:
+--   res1 <- lng325Bug()
+--   res2 <- secondStream()
+--   <- res1, res2

--- a/backend/air/src/main/scala/aqua/backend/air/Air.scala
+++ b/backend/air/src/main/scala/aqua/backend/air/Air.scala
@@ -144,7 +144,7 @@ object Air {
             showNext(inst)
             sb.append(space)
           case Air.Fold(iter, label, inst, lastInst) ⇒
-            sb.append(" ").append(s" ${iter.show} $label\n")
+            sb.append(s" ${iter.show} $label\n")
             showNext(inst)
             showNext(lastInst)
             sb.append(space)

--- a/integration-tests/aqua/examples/closures.aqua
+++ b/integration-tests/aqua/examples/closures.aqua
@@ -1,6 +1,7 @@
 aqua Closure declares *
 
 export LocalSrv, closureIn, closureOut, closureBig, closureOut2, lng58Bug, multipleClosuresBugLNG262, lng317Bug
+export lng325Bug, lng325BugTwoFuncs
 
 import "@fluencelabs/aqua-lib/builtin.aqua"
 

--- a/integration-tests/aqua/examples/closures.aqua
+++ b/integration-tests/aqua/examples/closures.aqua
@@ -128,7 +128,7 @@ func lng325Bug() -> string:
 
    job = () -> Job:
      run = (str: string) -> string:
-       brokenStream <- Op.identity(str)
+       brokenStream <- MyOp.identity(str)
        <- "run"
 
      <- Job(run = run)
@@ -142,7 +142,7 @@ func secondStream() -> string:
 
    secondJob = () -> Job:
      secondRun = (str: string) -> string:
-       brokenStream <- Op.identity(str)
+       brokenStream <- MyOp.identity(str)
        <- "run"
 
      <- Job(run = secondRun)

--- a/integration-tests/aqua/examples/closures.aqua
+++ b/integration-tests/aqua/examples/closures.aqua
@@ -115,3 +115,43 @@ func lng317Bug() -> []string:
    subnet_job <- disjoint_run{worker_job}()
    finalRes <- runJob(subnet_job)
    <- finalRes
+
+ability Job:
+    run(s: string) -> string
+
+func disrun(getJob: -> Job) -> Job:
+   j <- getJob()
+   <- j
+
+func lng325Bug() -> string:
+   brokenStream: *string
+
+   job = () -> Job:
+     run = (str: string) -> string:
+       brokenStream <- Op.identity(str)
+       <- "run"
+
+     <- Job(run = run)
+
+   subnetJob <- disrun(job)
+   subnetJob.run("firstStream string")
+   <- brokenStream!
+
+func secondStream() -> string:
+   brokenStream: *string
+
+   secondJob = () -> Job:
+     secondRun = (str: string) -> string:
+       brokenStream <- Op.identity(str)
+       <- "run"
+
+     <- Job(run = secondRun)
+
+   subnetJob <- disrun(secondJob)
+   subnetJob.run("secondStream string")
+   <- brokenStream!
+
+func lng325BugTwoFuncs() -> string, string:
+  res1 <- lng325Bug()
+  res2 <- secondStream()
+  <- res1, res2

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -122,6 +122,8 @@ import {
   closuresCall,
   multipleClosuresLNG262BugCall,
   lng317BugCall,
+  lng325BugCall,
+  lng325BugTwoFuncsCall
 } from "../examples/closures.js";
 import { closureArrowCaptureCall } from "../examples/closureArrowCapture.js";
 import {
@@ -1104,6 +1106,16 @@ describe("Testing examples", () => {
   it("closures.aqua bug LNG-317", async () => {
     let result = await lng317BugCall();
     expect(result).toEqual(["empty", "identity"]);
+  });
+
+  it("closures.aqua bug LNG-325", async () => {
+      let result = await lng325BugCall();
+      expect(result).toEqual("firstStream string");
+  });
+
+  it("closures.aqua bug LNG-325 two functions", async () => {
+      let result = await lng325BugTwoFuncsCall();
+      expect(result).toEqual(["firstStream string", "secondStream string"]);
   });
 
   it("closureArrowCapture.aqua", async () => {

--- a/integration-tests/src/examples/closures.ts
+++ b/integration-tests/src/examples/closures.ts
@@ -6,7 +6,9 @@ import {
   closureOut2,
   lng58Bug,
   lng317Bug,
-  multipleClosuresBugLNG262
+  multipleClosuresBugLNG262,
+  lng325Bug,
+  lng325BugTwoFuncs
 } from "../compiled/examples/closures.js";
 import { config } from "../config.js";
 
@@ -41,4 +43,12 @@ export async function multipleClosuresLNG262BugCall(): Promise<[number, number]>
 
 export async function lng317BugCall(): Promise<string[]> {
   return lng317Bug();
+}
+
+export async function lng325BugCall(): Promise<string> {
+  return lng325Bug();
+}
+
+export async function lng325BugTwoFuncsCall(): Promise<[string, string]> {
+  return lng325BugTwoFuncs();
 }

--- a/model/inline/src/main/scala/aqua/model/inline/RawValueInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/RawValueInliner.scala
@@ -123,9 +123,9 @@ object RawValueInliner extends Logging {
         else
           State.pure(args)
       }
-      // process separately exportTo that is a stream where function will push a result
       exportTo <- call.exportTo.traverse {
         case c@Call.Export(_, _, true) =>
+          // process streams from exportTo
           valueToModel(c.toRaw)
         case ce =>
           State.pure[S, (ValueModel, Option[OpModel.Tree])]((VarModel(ce.name, ce.`type`), None))

--- a/model/inline/src/main/scala/aqua/model/inline/RawValueInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/RawValueInliner.scala
@@ -125,9 +125,8 @@ object RawValueInliner extends Logging {
       }
       // process separately exportTo that is a stream where function will push a result
       exportTo <- call.exportTo.traverse {
-        case Call.Export(name, t, true) =>
-          val model = VarModel(name, t, Chain.empty)
-          Exports[S].resolved(name, model).as(model -> None)
+        case c@Call.Export(_, _, true) =>
+          valueToModel(c.toRaw)
         case ce =>
           State.pure[S, (ValueModel, Option[OpModel.Tree])]((VarModel(ce.name, ce.`type`), None))
       }

--- a/model/inline/src/main/scala/aqua/model/inline/RawValueInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/RawValueInliner.scala
@@ -125,8 +125,9 @@ object RawValueInliner extends Logging {
       }
       // process separately exportTo that is a stream where function will push a result
       exportTo <- call.exportTo.traverse {
-        case c@Call.Export(_, _, true) =>
-          valueToModel(c.toRaw)
+        case Call.Export(name, t, true) =>
+          val model = VarModel(name, t, Chain.empty)
+          Exports[S].resolved(name, model).as(model -> None)
         case ce =>
           State.pure[S, (ValueModel, Option[OpModel.Tree])]((VarModel(ce.name, ce.`type`), None))
       }

--- a/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/TagInliner.scala
@@ -403,12 +403,8 @@ object TagInliner extends Logging {
 
       case DeclareStreamTag(value) =>
         value match
-          case VarRaw(name, _) =>
-            for {
-              cd <- valueToModel(value)
-              (vm, prefix) = cd
-              _ <- Exports[S].resolved(name, vm)
-            } yield TagInlined.Empty(prefix = prefix)
+          case VarRaw(name, t) =>
+            Exports[S].resolved(name, VarModel(name, t)).as(TagInlined.Empty())
           case _ => none
 
       case ServiceIdTag(id, serviceType, name) =>

--- a/model/inline/src/main/scala/aqua/model/inline/tag/IfTagInliner.scala
+++ b/model/inline/src/main/scala/aqua/model/inline/tag/IfTagInliner.scala
@@ -8,17 +8,17 @@ import aqua.model.inline.state.{Arrows, Exports, Mangler}
 import aqua.model.inline.RawValueInliner.valueToModel
 import aqua.model.inline.TagInliner.canonicalizeIfStream
 import aqua.model.inline.Inline.parDesugarPrefixOpt
-
-import cats.data.Chain
+import cats.data.{Chain, State}
 import cats.syntax.flatMap.*
 import cats.syntax.apply.*
+import cats.Eval
 
 final case class IfTagInliner(
   valueRaw: ValueRaw
 ) {
   import IfTagInliner.*
 
-  def inlined[S: Mangler: Exports: Arrows] =
+  def inlined[S: Mangler: Exports: Arrows]: State[S, IfTagInlined] =
     (valueRaw match {
       // Optimize in case last operation is equality check
       case ApplyBinaryOpRaw(op @ (BinOp.Eq | BinOp.Neq), left, right, _) =>

--- a/model/raw/src/main/scala/aqua/raw/ops/Call.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/Call.scala
@@ -27,7 +27,7 @@ case class Call(args: List[ValueRaw], exportTo: List[Call.Export]) {
 object Call {
 
   // TODO docs
-  case class Export(name: String, `type`: Type) {
+  case class Export(name: String, `type`: Type, isExistingStream: Boolean = false) {
     def mapName(f: String => String): Export = copy(f(name))
 
     def toRaw: VarRaw = VarRaw(name, `type`)

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -216,10 +216,10 @@ case class CallArrowRawTag(
   override def usesVarNames: Set[String] = value.varNames ++ usesExportStreams
 
   override def mapValues(f: ValueRaw => ValueRaw): RawTag =
-    CallArrowRawTag(exportTo.mapStreams(f), value.map(f))
+    CallArrowRawTag(exportTo.map(_.mapStream(f)), value.map(f))
 
   override def renameExports(map: Map[String, String]): RawTag =
-    copy(exportTo = exportTo.renameExports(map))
+    copy(exportTo = exportTo.map(_.renameNonStream(map)))
 }
 
 object CallArrowRawTag {
@@ -307,10 +307,7 @@ case class ClosureTag(
   override def renameExports(map: Map[String, String]): RawTag =
     copy(func =
       func.copy(
-        name = map.getOrElse(func.name, func.name),
-        arrow = func.arrow.copy(
-          body = func.arrow.body.renameExports(map)
-        )
+        name = map.getOrElse(func.name, func.name)
       )
     )
 

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -308,7 +308,10 @@ case class ClosureTag(
   override def renameExports(map: Map[String, String]): RawTag =
     copy(func =
       func.copy(
-        name = map.getOrElse(func.name, func.name)
+        name = map.getOrElse(func.name, func.name),
+        arrow = func.arrow.copy(
+          body = func.arrow.body.renameExports(map)
+        )
       )
     )
 

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -215,24 +215,11 @@ case class CallArrowRawTag(
 
   override def usesVarNames: Set[String] = value.varNames ++ usesExportStreams
 
-  override def mapValues(f: ValueRaw => ValueRaw): RawTag = {
-    val newExportTo = exportTo.flatMap {
-      case ce@Call.Export(_, _, true) =>
-        f(ce.toRaw) match {
-          case VarRaw(name, baseType) => Some(Call.Export(name, baseType, true))
-          // unreachable
-          case _ => None
-        }
-      case ce => Some(ce)
-    }
-    CallArrowRawTag(newExportTo, value.map(f))
-  }
+  override def mapValues(f: ValueRaw => ValueRaw): RawTag =
+    CallArrowRawTag(exportTo.mapStreams(f), value.map(f))
 
   override def renameExports(map: Map[String, String]): RawTag =
-    copy(exportTo = exportTo.map {
-      case ce@Call.Export(_, _, true) => ce
-      case ce => ce.mapName(n => map.getOrElse(n, n))
-    })
+    copy(exportTo = exportTo.renameExports(map))
 }
 
 object CallArrowRawTag {

--- a/model/src/main/scala/aqua/model/FuncArrow.scala
+++ b/model/src/main/scala/aqua/model/FuncArrow.scala
@@ -3,8 +3,7 @@ package aqua.model
 import aqua.raw.arrow.FuncRaw
 import aqua.raw.ops.{Call, CallArrowRawTag, RawTag}
 import aqua.raw.value.{ValueRaw, VarRaw}
-import aqua.types.{ArrowType, Type}
-
+import aqua.types.{ArrowType, MutableStreamType, Type}
 import cats.syntax.option.*
 
 case class FuncArrow(
@@ -73,7 +72,9 @@ object FuncArrow {
 
     val call = Call(
       methodType.domain.toLabelledList().map(VarRaw.apply),
-      retVar.map(r => Call.Export(r.name, r.`type`)).toList
+      retVar.map { r =>
+        Call.Export(r.name, r.`type`, Type.isStreamType(r.`type`))
+      }.toList
     )
 
     val body = CallArrowRawTag.service(

--- a/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
@@ -31,7 +31,7 @@ class CallArrowSem[S[_]](val expr: CallArrowExpr[S]) extends AnyVal {
     (variables zip codomain.toList).traverse { case (v, t) =>
       N.read(v, mustBeDefined = false).flatMap {
         case Some(stream @ StreamType(st)) =>
-          T.ensureTypeMatches(v, st, t).as(Call.Export(v.value, stream))
+          T.ensureTypeMatches(v, st, t).as(Call.Export(v.value, stream, isExistingStream = true))
         case _ =>
           N.define(v, t).as(Call.Export(v.value, t))
       }

--- a/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/SemanticsSpec.scala
@@ -636,7 +636,7 @@ class SemanticsSpec extends AnyFlatSpec with Matchers with Inside {
         stream.`type` shouldBe StreamType(ScalarType.i32)
         matchChildren(forTag) { case (ParTag, parTag) =>
           matchChildren(parTag)(
-            { case (PushToStreamTag(VarRaw(varName, _), Call.Export(streamName, _)), _) =>
+            { case (PushToStreamTag(VarRaw(varName, _), Call.Export(streamName, _, _)), _) =>
               varName shouldBe "i"
               streamName shouldBe "stream"
             },

--- a/types/src/main/scala/aqua/types/Type.scala
+++ b/types/src/main/scala/aqua/types/Type.scala
@@ -519,6 +519,12 @@ object Type {
    * `StreamType` is collectible with canonicalization
    */
   type CollectibleType = DataType | StreamType
+  
+  def isStreamType(t: Type): Boolean =
+    t match {
+      case _: MutableStreamType => true
+      case _ => false
+    }
 
   given PartialOrder[Type] =
     CompareTypes.partialOrder

--- a/utils/mangler/src/main/scala/aqua/mangler/ManglerState.scala
+++ b/utils/mangler/src/main/scala/aqua/mangler/ManglerState.scala
@@ -2,8 +2,6 @@ package aqua.mangler
 
 import cats.Monoid
 
-import scala.annotation.tailrec
-
 case class ManglerState(namesNumbers: Map[String, Int] = Map.empty) {
 
   private def genName(name: String, n: Int) =


### PR DESCRIPTION
## Description
Compiler renames exported stream in a wrong way.

## Proposed Changes
Exports must be inlined as all variables for correct renaming.

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

