### PR TITLE
fix(compiler): Use `strict` to check types availability [LNG-334]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,14 +1,29 @@
 aqua A
 
-import SomeStruct from "./export.aqua"
-
 export main
 
-alias SomeStruct: string
+alias SomeAlias: string
+
+data NestedStruct:
+  a: SomeAlias
+
+data SomeStruct:
+  al: SomeAlias
+  nested: NestedStruct
+
+ability SomeAbility:
+  someStr: SomeStruct
+  nested: NestedStruct
+  al: SomeAlias
+  someFunc(ss: SomeStruct, nest: NestedStruct, al: SomeAlias) -> NestedStruct, SomeStruct, SomeAlias
 
 service Srv("a"):
-  check() -> SomeStruct
+  check(ss: SomeStruct, nest: NestedStruct, al: SomeAlias) -> NestedStruct
+  check2() -> SomeStruct
+  check3() -> SomeAlias
 
-func main() -> string:
-  Srv.check()
+func withAb{SomeAbility}() -> SomeStruct:
+  <- SomeAbility.someStr
+
+func main(ss: SomeStruct, nest: NestedStruct, al: SomeAlias) -> string:
   <- ""

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,92 +1,14 @@
 aqua A
 
-export get_logs
+import SomeStruct from "./export.aqua"
 
-service Op("op"):
-    id(s1: string)
-    identity(s: string) -> string
+export main
 
-service MyOp("op"):
-    id(s1: string)
-    identity(s: string) -> string
+alias SomeStruct: string
 
-func get_logs(a: string):
-    if a == "sdf":
-        streamA <- Op.identity("some serv")
-        Op.id(streamA)
-    streamA: *string
-    streamA <- Op.identity("stream")
+service Srv("a"):
+  check() -> SomeStruct
 
--- ability WorkerJob:
---   runOnSingleWorker(w: string) -> []string
---
--- func runJob(j: -> []string) -> []string:
---   <- j()
---
--- func disjoint_run{WorkerJob}() -> -> []string:
---   run = func () -> []string:
---       r <- WorkerJob.runOnSingleWorker("a")
---       <- r
---   <- run
---
--- func empty() -> string:
---   a = "empty"
---   <- a
---
--- func lng317Bug() -> []string:
---
---    res: *string
---
---    outer = () -> string:
---      <- empty()
---
---    clos = () -> -> []string:
---      job2 = () -> []string:
---        res <- outer()
---        res <- MyOp.identity("identity")
---        <- res
---      <- job2
---    worker_job = WorkerJob(runOnSingleWorker = clos())
---    subnet_job <- disjoint_run{worker_job}()
---    finalRes <- runJob(subnet_job)
---    <- finalRes
---
--- ability Job:
---     run(s: string) -> string
---
--- func disrun(getJob: -> Job) -> Job:
---    j <- getJob()
---    <- j
---
--- func lng325Bug() -> string:
---    brokenStream: *string
---
---    job = () -> Job:
---      run = (str: string) -> string:
---        brokenStream <- MyOp.identity(str)
---        <- "run"
---
---      <- Job(run = run)
---
---    subnetJob <- disrun(job)
---    subnetJob.run("firstStream string")
---    <- brokenStream!
---
--- func secondStream() -> string:
---    brokenStream: *string
---
---    secondJob = () -> Job:
---      secondRun = (str: string) -> string:
---        brokenStream <- MyOp.identity(str)
---        <- "run"
---
---      <- Job(run = secondRun)
---
---    subnetJob <- disrun(secondJob)
---    subnetJob.run("secondStream string")
---    <- brokenStream!
---
--- func lng325BugTwoFuncs() -> string, string:
---   res1 <- lng325Bug()
---   res2 <- secondStream()
---   <- res1, res2
+func main() -> string:
+  Srv.check()
+  <- ""

--- a/aqua-src/export.aqua
+++ b/aqua-src/export.aqua
@@ -1,7 +1,15 @@
-module FooBars declares *
+aqua FooBars declares *
 
 const DECLARE_CONST = "declare_const"
 const DECLARE_CONST2 = "declare_const2"
+
+-- alias SomeStruct: string
+
+data SomeStruct:
+  a: string
+
+-- service SomeStruct("ss"):
+--   a() -> string
 
 func foo() -> string:
     <- "I am MyFooBar foo"

--- a/language-server/language-server-api/src/main/scala/aqua/lsp/LocationsInterpreter.scala
+++ b/language-server/language-server-api/src/main/scala/aqua/lsp/LocationsInterpreter.scala
@@ -53,7 +53,6 @@ class LocationsInterpreter[S[_], X](using
 
   def pointLocations(locations: List[(String, Token[S])]): State[X, Unit] =
     modify { st =>
-      println("add locations: " + locations)
       st.addLocations(locations)
     }
 

--- a/language-server/language-server-api/src/main/scala/aqua/lsp/LocationsInterpreter.scala
+++ b/language-server/language-server-api/src/main/scala/aqua/lsp/LocationsInterpreter.scala
@@ -53,6 +53,7 @@ class LocationsInterpreter[S[_], X](using
 
   def pointLocations(locations: List[(String, Token[S])]): State[X, Unit] =
     modify { st =>
+      println("add locations: " + locations)
       st.addLocations(locations)
     }
 

--- a/language-server/language-server-api/src/test/scala/aqua/lsp/AquaLSPSpec.scala
+++ b/language-server/language-server-api/src/test/scala/aqua/lsp/AquaLSPSpec.scala
@@ -443,7 +443,7 @@ class AquaLSPSpec extends AnyFlatSpec with Matchers with Inside {
       res.checkLocations("SomeStruct", 0, n, main) shouldBe true
     }
 
-    res.checkTokenLoc(main, "SomeAbility", 0, someAb, printFiltered = true) shouldBe true
+    res.checkTokenLoc(main, "SomeAbility", 0, someAb) shouldBe true
     // from {SomeAbility} to 'ability SomeAbility'
     res.checkLocations("SomeAbility", 0, 1, main) shouldBe true
     // from 'SomeAbility.someStr' to {SomeAbility}
@@ -451,7 +451,6 @@ class AquaLSPSpec extends AnyFlatSpec with Matchers with Inside {
 
     res.checkTokenLoc(main, "Srv", 0, srvType) shouldBe true
     Range.inclusive(1, 3).foreach { n =>
-      println(n)
       res.checkLocations("Srv", 0, n, main) shouldBe true
     }
   }

--- a/parser/src/main/scala/aqua/parser/expr/func/ArrowExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/func/ArrowExpr.scala
@@ -1,11 +1,10 @@
 package aqua.parser.expr.func
 
-import aqua.parser.lexer.{ArrowTypeToken, BasicTypeToken, TypeToken, ValueToken}
+import aqua.parser.lexer.{ArrowTypeToken, BasicTypeToken, NamedTypeToken, TypeToken, ValueToken}
 import aqua.parser.lift.LiftParser
 import aqua.parser.lift.Span
 import aqua.parser.lift.Span.{P0ToSpan, PToSpan}
 import aqua.parser.{ArrowReturnError, Ast, Expr, ParserError}
-
 import cats.Comonad
 import cats.parse.Parser
 import cats.~>
@@ -15,6 +14,10 @@ case class ArrowExpr[F[_]](arrowTypeExpr: ArrowTypeToken[F])
 
   override def mapK[K[_]: Comonad](fk: F ~> K): ArrowExpr[K] =
     copy(arrowTypeExpr.mapK(fk))
+
+  lazy val abilities: List[(String, NamedTypeToken[F])] = arrowTypeExpr.args.collect {
+    case (Some(n), nt @ NamedTypeToken(_)) if n.value == nt.value => (n.value, nt)
+  }
 
 }
 

--- a/parser/src/main/scala/aqua/parser/expr/func/ArrowExpr.scala
+++ b/parser/src/main/scala/aqua/parser/expr/func/ArrowExpr.scala
@@ -14,11 +14,6 @@ case class ArrowExpr[F[_]](arrowTypeExpr: ArrowTypeToken[F])
 
   override def mapK[K[_]: Comonad](fk: F ~> K): ArrowExpr[K] =
     copy(arrowTypeExpr.mapK(fk))
-
-  lazy val abilities: List[(String, NamedTypeToken[F])] = arrowTypeExpr.args.collect {
-    case (Some(n), nt @ NamedTypeToken(_)) if n.value == nt.value => (n.value, nt)
-  }
-
 }
 
 object ArrowExpr extends Expr.AndIndented {

--- a/parser/src/main/scala/aqua/parser/lexer/TypeToken.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/TypeToken.scala
@@ -110,7 +110,8 @@ object ScalarTypeToken {
 case class ArrowTypeToken[S[_]: Comonad](
   override val unit: S[Unit],
   args: List[(Option[Name[S]], TypeToken[S])],
-  res: List[TypeToken[S]]
+  res: List[TypeToken[S]],
+  abilities: List[NamedTypeToken[S]] = Nil
 ) extends TypeToken[S] {
   override def as[T](v: T): S[T] = unit.as(v)
 
@@ -118,8 +119,9 @@ case class ArrowTypeToken[S[_]: Comonad](
     copy(
       fk(unit),
       args.map { case (n, t) => (n.map(_.mapK(fk)), t.mapK(fk)) },
-      res.map(_.mapK(fk))
-    )
+      res.map(_.mapK(fk)),
+      abilities.map(_.mapK(fk))
+  )
   def argTypes: List[TypeToken[S]] = args.map(_._2)
 }
 
@@ -133,8 +135,8 @@ object ArrowTypeToken {
   ).map(_.toList)
 
   // {SomeAb, SecondAb} for NamedTypeToken
-  def abilities(): P0[List[(Option[Name[S]], NamedTypeToken[S])]] =
-    (`{` *> comma(`Class`.surroundedBy(`/s*`).lift.map(s => Option(Name(s)) -> NamedTypeToken(s)))
+  def abilities(): P0[List[NamedTypeToken[S]]] =
+    (`{` *> comma(`Class`.surroundedBy(`/s*`).lift.map(NamedTypeToken(_)))
       .map(_.toList) <* `}`).?.map(_.getOrElse(List.empty))
 
   def `arrowdef`(argTypeP: P[TypeToken[Span.S]]): P[ArrowTypeToken[Span.S]] =
@@ -144,8 +146,9 @@ object ArrowTypeToken {
       val args = argsList.map(Option.empty[Name[Span.S]] -> _)
       ArrowTypeToken(
         point,
-        abs ++ args,
-        res
+        args,
+        res,
+        abs
       )
     }
 
@@ -155,7 +158,7 @@ object ArrowTypeToken {
         .surroundedBy(`/s*`)
     ) <* (`/s*` *> `)` <* ` `.?)) ~
       (` -> ` *> returnDef()).?).map { case (((abilities, point), args), res) =>
-      ArrowTypeToken(point, abilities ++ args, res.toList.flatMap(_.toList))
+      ArrowTypeToken(point, args, res.toList.flatMap(_.toList), abilities)
     }
 }
 

--- a/parser/src/main/scala/aqua/parser/lexer/TypeToken.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/TypeToken.scala
@@ -122,7 +122,8 @@ case class ArrowTypeToken[S[_]: Comonad](
       res.map(_.mapK(fk)),
       abilities.map(_.mapK(fk))
   )
-  def argTypes: List[TypeToken[S]] = args.map(_._2)
+  def argTypes: List[TypeToken[S]] = abilities ++ args.map(_._2)
+  lazy val absWithArgs: List[(Option[Name[S]], TypeToken[S])] = abilities.map(n => Some(n.asName) -> n) ++ args
 }
 
 object ArrowTypeToken {

--- a/parser/src/test/scala/aqua/AquaSpec.scala
+++ b/parser/src/test/scala/aqua/AquaSpec.scala
@@ -75,15 +75,17 @@ object AquaSpec {
 
   def toArrowType(
     args: List[BasicTypeToken[Id]],
-    res: Option[BasicTypeToken[Id]]
+    res: Option[BasicTypeToken[Id]],
+    abilities: List[NamedTypeToken[Id]] = Nil
   ): ArrowTypeToken[Id] =
-    ArrowTypeToken[Id]((), args.map(None -> _), res.toList)
+    ArrowTypeToken[Id]((), args.map(None -> _), res.toList, abilities)
 
   def toNamedArrow(
     args: List[(String, TypeToken[Id])],
-    res: List[BasicTypeToken[Id]]
+    res: List[BasicTypeToken[Id]],
+    abilities: List[NamedTypeToken[Id]] = Nil
   ): ArrowTypeToken[Id] =
-    ArrowTypeToken[Id]((), args.map(ab => Some(Name[Id](ab._1)) -> ab._2), res)
+    ArrowTypeToken[Id]((), args.map(ab => Some(Name[Id](ab._1)) -> ab._2), res, abilities)
 
   def toNamedArg(str: String, customType: String): Arg[Id] =
     Arg[Id](str, toNamedType(customType))

--- a/parser/src/test/scala/aqua/parser/ArrowTypeExprSpec.scala
+++ b/parser/src/test/scala/aqua/parser/ArrowTypeExprSpec.scala
@@ -33,11 +33,11 @@ class ArrowTypeExprSpec extends AnyFlatSpec with Matchers with AquaSpec {
         "onIn",
         toNamedArrow(
           List(
-            "SomeAb" -> toNamedType("SomeAb"),
             "a" -> toNamedType("Custom"),
             "b" -> toNamedType("Custom2")
           ),
-          Nil
+          Nil,
+          toNamedType("SomeAb") :: Nil
         )
       )
     )

--- a/parser/src/test/scala/aqua/parser/lexer/TypeTokenSpec.scala
+++ b/parser/src/test/scala/aqua/parser/lexer/TypeTokenSpec.scala
@@ -165,14 +165,11 @@ class TypeTokenSpec extends AnyFlatSpec with Matchers with EitherValues {
     arrowWithNames("{SomeAb, SecondAb}(a: A) -> B") should be(
       ArrowTypeToken[Id](
         (),
-        (Some(Name[Id]("SomeAb")) -> NamedTypeToken[Id]("SomeAb")) :: (Some(
-          Name[Id](
-            "SecondAb"
-          )
-        ) -> NamedTypeToken[Id]("SecondAb")) :: (
+        (
           Some(Name[Id]("a")) -> NamedTypeToken[Id]("A")
         ) :: Nil,
-        List(NamedTypeToken[Id]("B"))
+        List(NamedTypeToken[Id]("B")),
+        NamedTypeToken[Id]("SomeAb") :: NamedTypeToken[Id]("SecondAb") :: Nil
       )
     )
 

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
@@ -1,7 +1,6 @@
 package aqua.semantics.expr.func
 
 import aqua.parser.expr.func.ArrowExpr
-import aqua.parser.lexer.NamedTypeToken
 import aqua.raw.Raw
 import aqua.raw.arrow.ArrowRaw
 import aqua.raw.ops.*
@@ -35,9 +34,10 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
   ): Alg[ArrowType] = for {
     arrowType <- T.beginArrowScope(arrowTypeExpr)
     // add locations before ability will be defined as new variable definition
-    _ <- L.pointLocations(expr.abilities)
+    _ <- L.pointLocations(arrowTypeExpr.abilities.map(n => n.value -> n))
+    absAsArgs = arrowTypeExpr.abilities.map(_.asName)
     // Create local variables
-    _ <- arrowTypeExpr.args.flatMap { case (name, _) => name }
+    _ <- (absAsArgs ++ arrowTypeExpr.args.flatMap { case (name, _) => name })
       .zip(arrowType.domain.toList)
       .traverse {
         case (argName, t: ArrowType) =>

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
@@ -34,6 +34,8 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
     L: LocationsAlgebra[S, Alg]
   ): Alg[ArrowType] = for {
     arrowType <- T.beginArrowScope(arrowTypeExpr)
+    // add locations before ability will be defined as new variable definition
+    _ <- L.pointLocations(expr.abilities)
     // Create local variables
     _ <- arrowTypeExpr.args.flatMap { case (name, _) => name }
       .zip(arrowType.domain.toList)
@@ -43,7 +45,6 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
         case (argName, t) =>
           N.define(argName, t)
       }
-    _ <- L.pointLocations(expr.abilities)
   } yield arrowType
 
   def after[Alg[_]: Monad](

--- a/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/ArrowSem.scala
@@ -37,7 +37,7 @@ class ArrowSem[S[_]](val expr: ArrowExpr[S]) extends AnyVal {
     _ <- L.pointLocations(arrowTypeExpr.abilities.map(n => n.value -> n))
     absAsArgs = arrowTypeExpr.abilities.map(_.asName)
     // Create local variables
-    _ <- (absAsArgs ++ arrowTypeExpr.args.flatMap { case (name, _) => name })
+    _ <- arrowTypeExpr.absWithArgs.flatMap { case (name, _) => name }
       .zip(arrowType.domain.toList)
       .traverse {
         case (argName, t: ArrowType) =>

--- a/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/CallArrowSem.scala
@@ -1,10 +1,8 @@
 package aqua.semantics.expr.func
 
 import aqua.parser.expr.func.CallArrowExpr
-import aqua.parser.lexer.{CallArrowToken, IntoArrow, IntoField, PropertyToken, VarToken}
 import aqua.raw.Raw
 import aqua.raw.ops.{Call, CallArrowRawTag, FuncOp}
-import aqua.raw.value.CallArrowRaw
 import aqua.semantics.Prog
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
@@ -12,12 +10,9 @@ import aqua.semantics.rules.types.TypesAlgebra
 import aqua.types.{ProductType, StreamType, Type}
 
 import cats.Monad
-import cats.syntax.applicative.*
 import cats.syntax.apply.*
-import cats.syntax.comonad.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
-import cats.syntax.option.*
 import cats.syntax.traverse.*
 
 class CallArrowSem[S[_]](val expr: CallArrowExpr[S]) extends AnyVal {

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -99,7 +99,7 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
           case None =>
             (for {
               t <- OptionT(
-                T.getType(name.value)
+                T.getType(name.value, name)
               ).collect { case st: ServiceType => st }
                 // A hack to report name error, better to refactor
                 .flatTapNone(N.read(name))
@@ -429,7 +429,7 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
 
     lazy val nameTypeFromService = for {
       st <- OptionT(
-        T.getType(ab.value)
+        T.getType(ab.value, ab)
       ).collect { case st: ServiceType => st }
       rename <- OptionT(
         A.getServiceRename(ab)

--- a/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/ValuesAlgebra.scala
@@ -99,7 +99,7 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
           case None =>
             (for {
               t <- OptionT(
-                T.getType(name.value, name)
+                T.resolveType(name.asTypeToken, mustBeDefined = false)
               ).collect { case st: ServiceType => st }
                 // A hack to report name error, better to refactor
                 .flatTapNone(N.read(name))
@@ -429,7 +429,7 @@ class ValuesAlgebra[S[_], Alg[_]: Monad](using
 
     lazy val nameTypeFromService = for {
       st <- OptionT(
-        T.getType(ab.value, ab)
+        T.resolveType(ab, mustBeDefined = false)
       ).collect { case st: ServiceType => st }
       rename <- OptionT(
         A.getServiceRename(ab)

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypeResolution.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypeResolution.scala
@@ -14,7 +14,7 @@ import cats.syntax.validated.*
 
 final case class TypeResolution[S[_], +T](
   `type`: T,
-  definitions: List[(Token[S], NamedTypeToken[S])]
+  definitions: List[(Token[S], String)]
 )
 
 object TypeResolution {
@@ -59,10 +59,7 @@ object TypeResolution {
       case OptionTypeToken(_, dtt) =>
         resolveCollection(dtt, "Option", OptionType.apply)(state)
       case ntt: NamedTypeToken[S] =>
-        val defs = state
-          .getTypeDefinition(ntt.value)
-          .toList
-          .map(ntt -> _)
+        val defs = (ntt -> ntt.value) :: Nil
 
         state
           .getType(ntt.value)
@@ -104,7 +101,7 @@ object TypeResolution {
         ProductType.maybeLabelled(argsLabeledTypes),
         ProductType(resTypes)
       )
-      val defs = (argsTokens ++ resTokens)
+      val defs = argsTokens ++ resTokens
 
       TypeResolution(typ, defs)
     }.toValidated

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypeResolution.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypeResolution.scala
@@ -81,7 +81,7 @@ object TypeResolution {
   )(state: TypesState[S]): Res[S, ArrowType] = {
     val res = arrowTypeToken.res
       .traverse(typeToken => resolveTypeToken(typeToken)(state).toEither)
-    val args = arrowTypeToken.args.traverse { case (argName, typeToken) =>
+    val args = arrowTypeToken.absWithArgs.traverse { case (argName, typeToken) =>
       resolveTypeToken(typeToken)(state)
         .map(argName.map(_.value) -> _)
         .toEither

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypeResolution.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypeResolution.scala
@@ -14,7 +14,7 @@ import cats.syntax.validated.*
 
 final case class TypeResolution[S[_], +T](
   `type`: T,
-  definitions: List[(Token[S], String)]
+  occurrences: List[(Token[S], String)]
 )
 
 object TypeResolution {

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
@@ -11,13 +11,11 @@ import cats.data.OptionT
 
 trait TypesAlgebra[S[_], Alg[_]] {
 
-  def resolveType(token: TypeToken[S]): Alg[Option[Type]]
+  def resolveType(token: TypeToken[S], mustBeDefined: Boolean = true): Alg[Option[Type]]
 
   def resolveStreamType(token: TypeToken[S]): Alg[Option[StreamType]]
 
   def resolveNamedType(token: TypeToken[S]): Alg[Option[AbilityType | StructType]]
-
-  def getType(name: String, token: Token[S]): Alg[Option[Type]]
 
   def resolveArrowDef(arrowDef: ArrowTypeToken[S]): Alg[Option[ArrowType]]
 

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesAlgebra.scala
@@ -17,7 +17,7 @@ trait TypesAlgebra[S[_], Alg[_]] {
 
   def resolveNamedType(token: TypeToken[S]): Alg[Option[AbilityType | StructType]]
 
-  def getType(name: String): Alg[Option[Type]]
+  def getType(name: String, token: Token[S]): Alg[Option[Type]]
 
   def resolveArrowDef(arrowDef: ArrowTypeToken[S]): Alg[Option[ArrowType]]
 

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -180,8 +180,7 @@ class TypesInterpreter[S[_], X](using
     )
 
   override def defineAlias(name: NamedTypeToken[S], target: Type): State[X, Boolean] =
-    getState.map(_.definitions.get(name.value)).flatMap {
-      case Some(n) if n == name => State.pure(false)
+    getState.map(_.strict.get(name.value)).flatMap {
       case Some(_) => report.error(name, s"Type `${name.value}` was already defined").as(false)
       case None =>
         modify(_.defineType(name, target))
@@ -720,7 +719,7 @@ class TypesInterpreter[S[_], X](using
   )(
     ifNotDefined: => State[X, A]
   ): State[X, A] = getState
-    .map(_.definitions.get(name))
+    .map(_.strict.get(name))
     .flatMap {
       case Some(_) =>
         // TODO: Point to both locations here

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -270,7 +270,7 @@ class TypesInterpreter[S[_], X](using
                   ensureTypeMatches(arg, expectedType, argType)
                 }
 
-            locations.pointFieldLocation(abName, opName, op) *>
+            locations.pointFieldLocation(ab.name, opName, op) *>
               reportNotEnoughArguments *>
               reportTooManyArguments *>
               checkArgumentTypes.map(typesMatch =>

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesInterpreter.scala
@@ -611,7 +611,7 @@ class TypesInterpreter[S[_], X](using
     Applicative[ST]
       .product(
         // Collect argument types
-        token.args
+        token.absWithArgs
           .foldLeft(Chain.empty[(String, Type)].pure[ST]) {
             case (f, (Some(argName), argType)) =>
               f.flatMap(acc =>

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesState.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesState.scala
@@ -10,22 +10,17 @@ import cats.kernel.Monoid
 case class TypesState[S[_]](
   fields: Map[String, (Name[S], Type)] = Map(),
   strict: Map[String, Type] = Map.empty,
-  definitions: Map[String, NamedTypeToken[S]] = Map(),
   stack: List[TypesState.Frame[S]] = Nil
 ) {
   def isDefined(t: String): Boolean = strict.contains(t)
 
   def defineType(name: NamedTypeToken[S], `type`: Type): TypesState[S] =
     copy(
-      strict = strict.updated(name.value, `type`),
-      definitions = definitions.updated(name.value, name)
+      strict = strict.updated(name.value, `type`)
     )
 
   def getType(name: String): Option[Type] =
     strict.get(name)
-
-  def getTypeDefinition(name: String): Option[NamedTypeToken[S]] =
-    definitions.get(name)
 }
 
 object TypesState {
@@ -47,7 +42,6 @@ object TypesState {
     override def combine(x: TypesState[S], y: TypesState[S]): TypesState[S] =
       TypesState(
         strict = x.strict ++ y.strict,
-        definitions = x.definitions ++ y.definitions
       )
   }
 

--- a/semantics/src/main/scala/aqua/semantics/rules/types/TypesState.scala
+++ b/semantics/src/main/scala/aqua/semantics/rules/types/TypesState.scala
@@ -2,18 +2,10 @@ package aqua.semantics.rules.types
 
 import aqua.parser.lexer.*
 import aqua.raw.RawContext
-import aqua.raw.value.{FunctorRaw, IntoIndexRaw, LiteralRaw, PropertyRaw, ValueRaw}
+import aqua.raw.value.ValueRaw
 import aqua.types.*
 
-import cats.data.Validated.{Invalid, Valid}
-import cats.data.{Chain, NonEmptyChain, ValidatedNec}
 import cats.kernel.Monoid
-import cats.syntax.apply.*
-import cats.syntax.bifunctor.*
-import cats.syntax.functor.*
-import cats.syntax.option.*
-import cats.syntax.traverse.*
-import cats.syntax.validated.*
 
 case class TypesState[S[_]](
   fields: Map[String, (Name[S], Type)] = Map(),

--- a/semantics/src/test/scala/aqua/semantics/TypeResolutionSpec.scala
+++ b/semantics/src/test/scala/aqua/semantics/TypeResolutionSpec.scala
@@ -78,7 +78,7 @@ class TypeResolutionSpec extends AnyFlatSpec with Matchers with Inside {
       base <- baseTypes
       (token, expected) = base
     } inside(resolve(token, Map("Struct" -> structType))) {
-      case Valid(TypeResolution(result, Nil)) =>
+      case Valid(TypeResolution(result, _)) =>
         result shouldEqual expected
     }
   }
@@ -100,7 +100,7 @@ class TypeResolutionSpec extends AnyFlatSpec with Matchers with Inside {
           (btoken, btype) = base
           (mod, typ) = modifier
         } inside(resolve(mod(btoken), Map("Struct" -> structType))) {
-          case Valid(TypeResolution(result, Nil)) =>
+          case Valid(TypeResolution(result, _)) =>
             result shouldEqual typ(btype)
         }
       )


### PR DESCRIPTION
## Description
Use `strict` to prevent registering types when there is types with the same name imported from another file.
Also, fix token locations for services, abilities and structures.

fixes LNG-334
fixes LNG-335
fixes LNG-336
fixes LNG-299
fixes LNG-300

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

