### PR TITLE
fix: Allow spaces after aqua header

### DIFF
--- a/parser/src/main/scala/aqua/parser/head/ModuleExpr.scala
+++ b/parser/src/main/scala/aqua/parser/head/ModuleExpr.scala
@@ -81,13 +81,9 @@ object ModuleExpr extends HeaderExpr.Companion {
     (
       (` *`.with1 *> moduleWord) ~
         (` ` *> Ability.dotted) ~
-        ` *`.flatMap(spaces =>
-          // flatMap is costly, but there is no other way
-          // to allow either a bunch of spaces or a declares part
-          if (spaces.nonEmpty)
-            (`declares` *> ` ` *> nameOrAbListOrAll).?
-          else none.pure
-        )
+        (` declares ` *> nameOrAbListOrAll).backtrack
+          .map(_.some)
+          .orElse(` *`.as(none)) // Allow trailing spaces
     ).map {
       case ((word, name), None) =>
         ModuleExpr(word, name, None, Nil, Nil)

--- a/parser/src/main/scala/aqua/parser/head/ModuleExpr.scala
+++ b/parser/src/main/scala/aqua/parser/head/ModuleExpr.scala
@@ -71,7 +71,7 @@ object ModuleExpr extends HeaderExpr.Companion {
     comma[NameOrAb[Span.S]](nameOrAb).map(_.toList)
 
   private val nameOrAbListOrAll: Parser[Either[List[NameOrAb[Span.S]], Token[Span.S]]] =
-    nameOrAbList.map(Left(_)) | `star`.lift.map(Token.lift(_)).map(Right(_))
+    nameOrAbList.map(Left(_)) | (`star` <* ` *`).lift.map(Token.lift(_)).map(Right(_))
 
   private val moduleWord: Parser[Word[Span.S]] =
     (`module`.as(Word.Kind.Module).lift.backtrack |

--- a/parser/src/main/scala/aqua/parser/lexer/Token.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/Token.scala
@@ -39,6 +39,7 @@ object Token {
   val `module`: P[Unit] = P.string("module")
   val `aqua-word`: P[Unit] = P.string("aqua")
   val `declares`: P[Unit] = P.string("declares")
+  val ` declares ` : P[Unit] = `declares`.surroundedBy(` `)
   val `declare`: P[Unit] = P.string("declare")
   val `_export`: P[Unit] = P.string("export")
   val `star`: P[Unit] = P.char('*')

--- a/parser/src/main/scala/aqua/parser/lexer/Token.scala
+++ b/parser/src/main/scala/aqua/parser/lexer/Token.scala
@@ -39,7 +39,6 @@ object Token {
   val `module`: P[Unit] = P.string("module")
   val `aqua-word`: P[Unit] = P.string("aqua")
   val `declares`: P[Unit] = P.string("declares")
-  val ` declares ` : P[Unit] = `declares`.surroundedBy(` `)
   val `declare`: P[Unit] = P.string("declare")
   val `_export`: P[Unit] = P.string("export")
   val `star`: P[Unit] = P.char('*')

--- a/parser/src/test/scala/aqua/parser/head/ModuleSpec.scala
+++ b/parser/src/test/scala/aqua/parser/head/ModuleSpec.scala
@@ -13,17 +13,60 @@ import org.scalatest.matchers.should.Matchers
 class ModuleSpec extends AnyFlatSpec with Matchers with AquaSpec {
   import AquaSpec.*
 
-  "module header" should "be parsed" in {
-    ModuleExpr.p.parseAll("aqua MyModule").value.mapK(spanToId) should be(
-      ModuleExpr(
-        ModuleExpr.Word[Id](Id(ModuleExpr.Word.Kind.Aqua)),
-        toAb("MyModule"),
-        None,
-        Nil,
-        Nil
-      )
+  val myModule = ModuleExpr(
+    ModuleExpr.Word[Id](Id(ModuleExpr.Word.Kind.Aqua)),
+    toAb("MyModule"),
+    None,
+    Nil,
+    Nil
+  )
+
+  val declaresAll = myModule.copy(
+    declareAll = Some(Token.lift[Id, Unit](()))
+  )
+
+  def declares(symbols: List[String]) =
+    myModule.copy(
+      declareNames = symbols.filter(_.headOption.exists(_.isLower)).map(toName),
+      declareCustom = symbols.filter(_.headOption.exists(_.isUpper)).map(toAb)
     )
 
+  def parseModuleExpr(expr: String): ModuleExpr[Id] =
+    ModuleExpr.p
+      .parseAll(expr)
+      .value
+      .mapK(spanToId)
+
+  "module expr" should "be parsed" in {
+    parseModuleExpr("aqua MyModule") should be(myModule)
+  }
+
+  it should "be parsed with spaces in the end" in {
+    (0 to 10).foreach(sp => parseModuleExpr("aqua MyModule" + " ".repeat(sp)) should be(myModule))
+  }
+
+  it should "be parsed with spaces in the beginning" in {
+    (0 to 10).foreach(sp => parseModuleExpr(" ".repeat(sp) + "aqua MyModule") should be(myModule))
+  }
+
+  it should "be parsed with `declares *`" in {
+    parseModuleExpr("aqua MyModule declares *") should be(declaresAll)
+  }
+
+  it should "be parsed with `declares *` with spaces in the end" in {
+    parseModuleExpr("aqua MyModule declares *") should be(declaresAll)
+  }
+
+  it should "be parsed with `declares`" in {
+    List("a", "myFunc", "MyService", "MyAbility", "CONST").inits.takeWhile(_.nonEmpty).foreach {
+      decl =>
+        parseModuleExpr(s"aqua MyModule declares " + decl.mkString(", ")) should be(
+          declares(decl)
+        )
+    }
+  }
+
+  "module header" should "be parsed" in {
     Header.p
       .parseAll(s"""aqua MyModule declares *
                    |""".stripMargin)
@@ -31,15 +74,7 @@ class ModuleSpec extends AnyFlatSpec with Matchers with AquaSpec {
       .headers
       .headOption
       .get
-      .mapK(spanToId) should be(
-      ModuleExpr(
-        ModuleExpr.Word[Id](Id(ModuleExpr.Word.Kind.Aqua)),
-        toAb("MyModule"),
-        Some(Token.lift[Id, Unit](())),
-        Nil,
-        Nil
-      )
-    )
+      .mapK(spanToId) should be(declaresAll)
   }
 
 }

--- a/parser/src/test/scala/aqua/parser/head/ModuleSpec.scala
+++ b/parser/src/test/scala/aqua/parser/head/ModuleSpec.scala
@@ -54,7 +54,9 @@ class ModuleSpec extends AnyFlatSpec with Matchers with AquaSpec {
   }
 
   it should "be parsed with `declares *` with spaces in the end" in {
-    parseModuleExpr("aqua MyModule declares *") should be(declaresAll)
+    (0 to 10).foreach(sp =>
+      parseModuleExpr("aqua MyModule declares *" + " ".repeat(sp)) should be(declaresAll)
+    )
   }
 
   it should "be parsed with `declares`" in {


### PR DESCRIPTION
## Description
Fix parsing so that it allows additional spaces after `aqua` header

## Checklist
- [ ] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

