### PR TITLE
fix(compiler): Return error if SemanticError occures [LNG-356]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,8 +1,29 @@
 aqua Job declares *
 
+export aaa, bbb
+
 data Peer:
   id: string
 
-func aaa() -> string: 
-  p = Pe2er(id = "123")
-  <- p.id
+func aaa() -> Peer:
+  peer1 = Peer(id = "123")
+  peer2 = Peer(id = peer1.id)
+  <- peer2
+
+data BrokenStruct:
+  fff: UnknownType
+
+alias BrokenAlias: str3ng
+
+ability BrokenAbility:
+  fff: str4ng
+
+const BROKEN_CONST = UNKNOWN_CONST
+
+func bbb() -> string:
+  <- 323
+
+func ccc() -> Peer:
+  peer1 = Peer(id = "123")
+  peer2 = Peer(id = peer1.id)
+  <- peer2

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,10 +1,8 @@
-aqua Main
+aqua Job declares *
 
-export main
+data Peer:
+  id: string
 
-func reward(amount: ?u32) -> u32:
-  result = ?[amount! / 10, 0]
-  <- result!
-
-func main(a: u32) -> u32:
-  <- reward(?[a])
+func aaa() -> string: 
+  p = Pe2er(id = "123")
+  <- p.id

--- a/language-server/language-server-api/src/main/scala/aqua/lsp/LspContext.scala
+++ b/language-server/language-server-api/src/main/scala/aqua/lsp/LspContext.scala
@@ -33,9 +33,9 @@ object LspContext {
   def blank[S[_]]: LspContext[S] = LspContext[S](raw = RawContext())
 
   given [S[_]]: Monoid[LspContext[S]] with {
-    override def empty = blank[S]
+    override def empty: LspContext[S] = blank[S]
 
-    override def combine(x: LspContext[S], y: LspContext[S]) =
+    override def combine(x: LspContext[S], y: LspContext[S]): LspContext[S] =
       LspContext[S](
         raw = x.raw |+| y.raw,
         abDefinitions = x.abDefinitions ++ y.abDefinitions,
@@ -52,7 +52,7 @@ object LspContext {
   given [S[_]]: Picker[LspContext[S]] with {
     import aqua.semantics.header.Picker.*
 
-    override def blank: LspContext[S] = LspContext[S](Picker[RawContext].blank, Map.empty)
+    override def blank: LspContext[S] = LspContext.blank[S]
     override def exports(ctx: LspContext[S]): Map[String, Option[String]] = ctx.raw.exports
 
     override def isAbility(ctx: LspContext[S], name: String): Boolean =

--- a/language-server/language-server-api/src/main/scala/aqua/lsp/LspSemantics.scala
+++ b/language-server/language-server-api/src/main/scala/aqua/lsp/LspSemantics.scala
@@ -8,6 +8,9 @@ import aqua.semantics.*
 import aqua.semantics.header.Picker.*
 import aqua.semantics.rules.locations.LocationsState
 
+import cats.data.{EitherT, NonEmptyChain, Writer}
+import cats.syntax.functor.*
+import cats.syntax.applicative.*
 import monocle.Lens
 import monocle.macros.GenLens
 
@@ -54,21 +57,17 @@ class LspSemantics[S[_]](
       .interpret(ast, withConstants.raw)
       .run(initState)
       .map { case (state, ctx) =>
-        (
-          state,
-          LspContext(
-            raw = ctx,
-            rootArrows = state.names.rootArrows,
-            constants = state.names.constants,
-            abDefinitions = state.abilities.definitions,
-            importTokens = importTokens,
-            variables = state.locations.variables,
-            errors = state.errors.toList,
-            warnings = state.warnings.toList
-          )
-        )
+        LspContext(
+          raw = ctx,
+          rootArrows = state.names.rootArrows,
+          constants = state.names.constants,
+          abDefinitions = state.abilities.definitions,
+          importTokens = importTokens,
+          variables = state.locations.variables,
+          errors = state.errors.toList,
+          warnings = state.warnings.toList
+        ).pure[Result]
       }
-      .map(stateToResult)
       .value
   }
 }

--- a/language-server/language-server-api/src/main/scala/aqua/lsp/LspSemantics.scala
+++ b/language-server/language-server-api/src/main/scala/aqua/lsp/LspSemantics.scala
@@ -63,27 +63,21 @@ class LspSemantics[S[_]](
       .interpret(ast, withConstants.raw)
       .run(initState)
       .map { case (state, ctx) =>
-        EitherT(
-          Writer
-            .tell(state.warnings)
-            .as(
-              NonEmptyChain
-                .fromChain(state.errors)
-                .toLeft(
-                  LspContext(
-                    raw = ctx,
-                    rootArrows = state.names.rootArrows,
-                    constants = state.names.constants,
-                    abDefinitions = state.abilities.definitions,
-                    importTokens = importTokens,
-                    variables = state.locations.variables,
-                    errors = state.errors.toList,
-                    warnings = state.warnings.toList
-                  )
-                )
-            )
+        (
+          state,
+          LspContext(
+            raw = ctx,
+            rootArrows = state.names.rootArrows,
+            constants = state.names.constants,
+            abDefinitions = state.abilities.definitions,
+            importTokens = importTokens,
+            variables = state.locations.variables,
+            errors = state.errors.toList,
+            warnings = state.warnings.toList
+          )
         )
       }
+      .map(stateToResult)
       .value
   }
 }

--- a/language-server/language-server-api/src/main/scala/aqua/lsp/LspSemantics.scala
+++ b/language-server/language-server-api/src/main/scala/aqua/lsp/LspSemantics.scala
@@ -2,21 +2,12 @@ package aqua.lsp
 
 import aqua.parser.Ast
 import aqua.parser.head.{ImportExpr, ImportFromExpr, UseExpr, UseFromExpr}
-import aqua.parser.lexer.{LiteralToken, Token}
+import aqua.parser.lexer.LiteralToken
 import aqua.raw.ConstantRaw
+import aqua.semantics.*
 import aqua.semantics.header.Picker.*
 import aqua.semantics.rules.locations.LocationsState
-import aqua.semantics.{CompilerState, RawSemantics, SemanticError, SemanticWarning, Semantics}
 
-import cats.data.Validated.{Invalid, Valid}
-import cats.data.{EitherT, NonEmptyChain, ValidatedNec, Writer}
-import cats.syntax.applicative.*
-import cats.syntax.apply.*
-import cats.syntax.either.*
-import cats.syntax.flatMap.*
-import cats.syntax.foldable.*
-import cats.syntax.functor.*
-import cats.syntax.reducible.*
 import monocle.Lens
 import monocle.macros.GenLens
 

--- a/language-server/language-server-api/src/test/scala/aqua/lsp/AquaLSPSpec.scala
+++ b/language-server/language-server-api/src/test/scala/aqua/lsp/AquaLSPSpec.scala
@@ -2,15 +2,15 @@ package aqua.lsp
 
 import aqua.compiler.FileIdString.given_FileId_String
 import aqua.compiler.{AquaCompilerConf, AquaError, AquaSources}
-import aqua.compiler.AquaError.CompileError
 import aqua.parser.Parser
 import aqua.parser.lexer.Token
 import aqua.parser.lift.Span
 import aqua.parser.lift.Span.S
 import aqua.raw.ConstantRaw
 import aqua.semantics.rules.locations.{DefinitionInfo, TokenLocation, VariableInfo}
-import aqua.semantics.RulesViolated
+import aqua.semantics.{RulesViolated, SemanticError}
 import aqua.types.*
+
 import cats.Id
 import cats.data.*
 import org.scalatest.Inside
@@ -132,6 +132,16 @@ class AquaLSPSpec extends AnyFlatSpec with Matchers with Inside {
         println(ee)
         ee
       }
+
+  def insideError(err: SemanticError[S], str: String, pos: Int, code: String) = {
+    inside(err) { case RulesViolated(token, _) =>
+      val span = token.unit._1
+      val locatedOp = getByPosition(code, str, pos)
+      locatedOp shouldBe defined
+      val located = locatedOp.get
+      (span.startIndex, span.endIndex) shouldBe (located._1, located._2)
+    }
+  }
 
   it should "return right tokens" in {
     val main =
@@ -546,7 +556,7 @@ class AquaLSPSpec extends AnyFlatSpec with Matchers with Inside {
     res.checkLocations("Abilyy", 0, 3, main) shouldBe true
   }
 
-  it should "return correct errors" in {
+  it should "return correct locations of errors on exported functions (LNG-356)" in {
     val main =
       """aqua Job declares *
         |
@@ -564,23 +574,80 @@ class AquaLSPSpec extends AnyFlatSpec with Matchers with Inside {
 
     val imports = Map.empty[String, String]
 
-    val res = compile(src, imports).toEither.swap.toOption.get.toChain.toList
+    val res = compile(src, imports).toEither.toOption.get.values.head
 
-    def insideError(err: AquaError[String, String, Span.S], str: String, pos: Int) = {
-      inside(err) {
-        case CompileError(RulesViolated[S](token: Token[S], _)) =>
-          val span = token.unit._1
-          val locatedOp = getByPosition(main, str, pos)
-          locatedOp shouldBe defined
-          val located = locatedOp.get
-          (span.startIndex, span.endIndex) shouldBe (located._1, located._2)
-      }
-    }
+    val errors = res.errors
 
-
-    res.length shouldBe 3
-    insideError(res.head, "Pe2er", 0)
-    insideError(res(1), "peer", 1)
-    insideError(res(2), "string", 1)
+    insideError(errors.head, "Pe2er", 0, main)
+    insideError(errors(1), "peer", 1, main)
+    insideError(errors(2), "string", 1, main)
   }
+
+  it should "return correct locations in functions even if there is errors in other parts of a code" in {
+    val main =
+      """aqua Job declares *
+        |
+        |export aaa, bbb
+        |
+        |data Peer:
+        |  id: string
+        |
+        |func aaa() -> Peer:
+        |  peer1 = Peer(id = "123")
+        |  peer2 = Peer(id = peer1.id)
+        |  <- peer2
+        |
+        |data BrokenStruct:
+        |  fff: UnknownType1
+        |
+        |alias BrokenAlias: UnknownType2
+        |
+        |ability BrokenAbility:
+        |  fff: UnknownType3
+        |
+        |const BROKEN_CONST = UNKNOWN_CONST
+        |
+        |func bbb() -> string:
+        |  <- 323
+        |
+        |func ccc() -> Peer:
+        |  peer1 = Peer(id = "123")
+        |  peer2 = Peer(id = peer1.id)
+        |  <- peer2
+        |
+        |""".stripMargin
+    val src = Map(
+      "index.aqua" -> main
+    )
+
+    val imports = Map.empty[String, String]
+
+    val res = compile(src, imports).toOption.get.values.head
+    val errors = res.errors
+
+    // 'aaa' function
+    res.checkLocations("Peer", 0, 1, main) shouldBe true
+    res.checkLocations("Peer", 0, 2, main) shouldBe true
+    res.checkLocations("Peer", 0, 3, main) shouldBe true
+    res.checkLocations("peer1", 0, 1, main) shouldBe true
+    res.checkLocations("peer1", 0, 1, main) shouldBe true
+
+    // 'ccc' function
+    res.checkLocations("Peer", 0, 4, main) shouldBe true
+    res.checkLocations("Peer", 0, 5, main) shouldBe true
+    res.checkLocations("Peer", 0, 6, main) shouldBe true
+    res.checkLocations("peer1", 2, 3, main) shouldBe true
+    res.checkLocations("peer1", 2, 3, main) shouldBe true
+
+    // errors
+    insideError(errors.head, "UnknownType1", 0, main)
+    insideError(errors(1), "BrokenStruct", 0, main)
+    insideError(errors(2), "UnknownType2", 0, main)
+    insideError(errors(3), "UnknownType3", 0, main)
+    insideError(errors(4), "BrokenAbility", 0, main)
+    insideError(errors(5), "UNKNOWN_CONST", 0, main)
+    insideError(errors(6), "323", 0, main)
+    insideError(errors(7), "string", 1, main)
+  }
+
 }

--- a/model/raw/src/main/scala/aqua/raw/ErroredPart.scala
+++ b/model/raw/src/main/scala/aqua/raw/ErroredPart.scala
@@ -1,0 +1,10 @@
+package aqua.raw
+
+import aqua.types.{BottomType, Type}
+
+// Part for structures that have errors inside but must be registered in context
+case class ErroredPart(name: String) extends RawPart {
+  override def rawPartType: Type = BottomType
+
+  override def rename(s: String): RawPart = copy(name = s)
+}

--- a/model/raw/src/main/scala/aqua/raw/RawContext.scala
+++ b/model/raw/src/main/scala/aqua/raw/RawContext.scala
@@ -90,7 +90,7 @@ case class RawContext(
     parts.map { case (_, p) => p.name }.toList.toSet
 
   lazy val declaredNames: Set[String] =
-    allNames.filter(declares.contains)
+    allNames.intersect(declares)
 
   override def toString: String =
     s"""|module: ${module.getOrElse("unnamed")}
@@ -109,7 +109,7 @@ object RawContext {
 
     override def empty: RawContext = blank
 
-    override def combine(x: RawContext, y: RawContext) =
+    override def combine(x: RawContext, y: RawContext): RawContext =
       RawContext(
         x.module orElse y.module,
         x.declares ++ y.declares,

--- a/semantics/src/main/scala/aqua/semantics/RawSemantics.scala
+++ b/semantics/src/main/scala/aqua/semantics/RawSemantics.scala
@@ -45,17 +45,7 @@ class RawSemantics[S[_]](
     RawSemantics
       .interpret(ast, withConstants)
       .run(CompilerState.init(withConstants))
-      .map { case (state, ctx) =>
-        EitherT(
-          Writer
-            .tell(state.warnings)
-            .as(
-              NonEmptyChain
-                .fromChain(state.errors)
-                .toLeft(ctx)
-            )
-        )
-      }
+      .map(stateToResult)
       // TODO: return as Eval
       .value
   }

--- a/semantics/src/main/scala/aqua/semantics/RawSemantics.scala
+++ b/semantics/src/main/scala/aqua/semantics/RawSemantics.scala
@@ -45,8 +45,17 @@ class RawSemantics[S[_]](
     RawSemantics
       .interpret(ast, withConstants)
       .run(CompilerState.init(withConstants))
-      .map(stateToResult)
-      // TODO: return as Eval
+      .map { case (state, ctx) =>
+        EitherT(
+          Writer
+            .tell(state.warnings)
+            .as(
+              NonEmptyChain
+                .fromChain(state.errors)
+                .toLeft(ctx)
+            )
+        )
+      }
       .value
   }
 }

--- a/semantics/src/main/scala/aqua/semantics/Semantics.scala
+++ b/semantics/src/main/scala/aqua/semantics/Semantics.scala
@@ -3,7 +3,6 @@ package aqua.semantics
 import aqua.parser.Ast
 
 import cats.data.{Chain, EitherT, NonEmptyChain, Writer}
-import cats.syntax.functor.*
 
 trait Semantics[S[_], C] {
 
@@ -24,15 +23,4 @@ trait Semantics[S[_], C] {
     ast: Ast[S],
     init: C
   ): ProcessResult
-
-  def stateToResult(state: CompilerState[S], ctx: C): ProcessResult =
-    EitherT(
-      Writer
-        .tell(state.warnings)
-        .as(
-          NonEmptyChain
-            .fromChain(state.errors)
-            .toLeft(ctx)
-        )
-    )
 }

--- a/semantics/src/main/scala/aqua/semantics/Semantics.scala
+++ b/semantics/src/main/scala/aqua/semantics/Semantics.scala
@@ -3,6 +3,7 @@ package aqua.semantics
 import aqua.parser.Ast
 
 import cats.data.{Chain, EitherT, NonEmptyChain, Writer}
+import cats.syntax.functor.*
 
 trait Semantics[S[_], C] {
 
@@ -23,4 +24,15 @@ trait Semantics[S[_], C] {
     ast: Ast[S],
     init: C
   ): ProcessResult
+
+  def stateToResult(state: CompilerState[S], ctx: C): ProcessResult =
+    EitherT(
+      Writer
+        .tell(state.warnings)
+        .as(
+          NonEmptyChain
+            .fromChain(state.errors)
+            .toLeft(ctx)
+        )
+    )
 }

--- a/semantics/src/main/scala/aqua/semantics/expr/AbilitySem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/AbilitySem.scala
@@ -1,24 +1,15 @@
 package aqua.semantics.expr
 
 import aqua.parser.expr.AbilityExpr
-import aqua.raw.{Raw, TypeRaw}
-import aqua.parser.lexer.{Name, NamedTypeToken}
+import aqua.raw.{ErroredPart, Raw, TypeRaw}
 import aqua.semantics.Prog
-import aqua.semantics.rules.ValuesAlgebra
-import aqua.semantics.rules.abilities.AbilitiesAlgebra
 import aqua.semantics.rules.definitions.DefinitionsAlgebra
-import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
-import aqua.types.{AbilityType, ArrowType, Type}
 
+import cats.Monad
 import cats.syntax.apply.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
-import cats.syntax.applicative.*
-import cats.syntax.semigroupal.*
-import cats.syntax.traverse.*
-import cats.Monad
-import cats.data.{NonEmptyList, NonEmptyMap}
 
 class AbilitySem[S[_]](val expr: AbilityExpr[S]) extends AnyVal {
 
@@ -32,7 +23,7 @@ class AbilitySem[S[_]](val expr: AbilityExpr[S]) extends AnyVal {
         fields = defs.view.mapValues(d => d.name -> d.`type`).toMap
         abilityType <- T.defineAbilityType(expr.name, fields)
         result = abilityType.map(st => TypeRaw(expr.name.value, st))
-      } yield result.getOrElse(Raw.error("Ability types unresolved"))
+      } yield result.getOrElse(ErroredPart(expr.name.value))
     )
   }
 }

--- a/semantics/src/main/scala/aqua/semantics/expr/AliasSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/AliasSem.scala
@@ -1,10 +1,9 @@
 package aqua.semantics.expr
 
 import aqua.parser.expr.AliasExpr
-import aqua.raw.{Raw, TypeRaw}
+import aqua.raw.{ErroredPart, Raw, TypeRaw}
 import aqua.semantics.Prog
 import aqua.semantics.rules.types.TypesAlgebra
-
 import cats.Applicative
 import cats.Monad
 import cats.syntax.flatMap.*
@@ -15,6 +14,6 @@ class AliasSem[S[_]](val expr: AliasExpr[S]) extends AnyVal {
   def program[Alg[_]: Monad](using T: TypesAlgebra[S, Alg]): Prog[Alg, Raw] =
     T.resolveType(expr.target).flatMap {
       case Some(t) => T.defineAlias(expr.name, t) as (TypeRaw(expr.name.value, t): Raw)
-      case None => Applicative[Alg].pure(Raw.error("Alias type unresolved"))
+      case None => Applicative[Alg].pure(ErroredPart(expr.name.value))
     }
 }

--- a/semantics/src/main/scala/aqua/semantics/expr/ConstantSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ConstantSem.scala
@@ -1,7 +1,7 @@
 package aqua.semantics.expr
 
 import aqua.parser.expr.ConstantExpr
-import aqua.raw.{ConstantRaw, Raw}
+import aqua.raw.{ConstantRaw, ErroredPart, Raw}
 import aqua.semantics.Prog
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
@@ -27,12 +27,12 @@ class ConstantSem[S[_]](val expr: ConstantExpr[S]) extends AnyVal {
             case true =>
               Raw.empty(s"Constant with name ${expr.name} was already defined, skipping")
             case false =>
-              Raw.error(s"Constant with name ${expr.name} was defined with different type")
+              ErroredPart(expr.name.value)
           }
         case (Some(_), _, _) =>
           Raw.error(s"Name '${expr.name.value}' was already defined").pure[Alg]
         case (_, None, _) =>
-          Raw.error(s"There is no such variable ${expr.value}").pure[Alg]
+          ErroredPart(expr.name.value).pure[Alg]
         case (_, Some(t), _) =>
           N.defineConstant(expr.name, t._2) as (ConstantRaw(
             expr.name.value,

--- a/semantics/src/main/scala/aqua/semantics/expr/DataStructSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/DataStructSem.scala
@@ -1,13 +1,12 @@
 package aqua.semantics.expr
 
 import aqua.parser.expr.DataStructExpr
-import aqua.raw.{Raw, TypeRaw}
+import aqua.raw.{ErroredPart, Raw, TypeRaw}
 import aqua.semantics.Prog
 import aqua.semantics.rules.definitions.DefinitionsAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
 import aqua.types.StructType
-
 import cats.syntax.functor.*
 import cats.syntax.applicative.*
 import cats.syntax.traverse.*
@@ -26,7 +25,7 @@ class DataStructSem[S[_]](val expr: DataStructExpr[S]) extends AnyVal {
         fields = defs.view.mapValues(d => d.name -> d.`type`).toMap
         structType <- T.defineStructType(expr.name, fields)
         result = structType.map(st => TypeRaw(expr.name.value, st))
-      } yield result.getOrElse(Raw.error("Data struct types unresolved"))
+      } yield result.getOrElse(ErroredPart(expr.name.value))
     )
 
 }

--- a/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
@@ -1,5 +1,6 @@
 package aqua.semantics.expr
 
+import aqua.helpers.syntax.optiont.withFilterF
 import aqua.parser.expr.ServiceExpr
 import aqua.raw.{ErroredPart, Raw, ServiceRaw}
 import aqua.semantics.Prog

--- a/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
@@ -1,7 +1,7 @@
 package aqua.semantics.expr
 
 import aqua.parser.expr.ServiceExpr
-import aqua.raw.{Raw, ServiceRaw}
+import aqua.raw.{ErroredPart, Raw, ServiceRaw}
 import aqua.semantics.Prog
 import aqua.semantics.rules.ValuesAlgebra
 import aqua.semantics.rules.abilities.AbilitiesAlgebra
@@ -9,16 +9,16 @@ import aqua.semantics.rules.definitions.DefinitionsAlgebra
 import aqua.semantics.rules.names.NamesAlgebra
 import aqua.semantics.rules.types.TypesAlgebra
 
-import cats.data.EitherT
-import cats.syntax.either.*
-import cats.syntax.option.*
-import cats.syntax.apply.*
-import cats.syntax.flatMap.*
-import cats.syntax.functor.*
-import cats.syntax.traverse.*
-import cats.syntax.foldable.*
-import cats.syntax.applicative.*
 import cats.Monad
+import cats.data.EitherT
+import cats.syntax.applicative.*
+import cats.syntax.apply.*
+import cats.syntax.either.*
+import cats.syntax.flatMap.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
+import cats.syntax.option.*
+import cats.syntax.traverse.*
 
 class ServiceSem[S[_]](val expr: ServiceExpr[S]) extends AnyVal {
 
@@ -27,44 +27,45 @@ class ServiceSem[S[_]](val expr: ServiceExpr[S]) extends AnyVal {
     T: TypesAlgebra[S, Alg],
     V: ValuesAlgebra[S, Alg],
     D: DefinitionsAlgebra[S, Alg]
-  ): EitherT[Alg, Raw, ServiceRaw] = for {
-    arrows <- EitherT.fromOptionF(
-      // TODO:  Move to purgeDefs here, allow not only arrows
-      //        from parsing, throw errors here
-      D.purgeArrows(expr.name),
-      Raw.error("Service has no arrows")
-    )
-    arrowsByName = arrows.map { case (name, arrow) =>
-      name.value -> (name, arrow)
-    }.toNem
-    defaultId <- expr.id.traverse(id =>
-      EitherT.fromOptionF(
-        V.valueToStringRaw(id),
-        Raw.error("Failed to resolve default service id")
+  ): EitherT[Alg, Raw, ServiceRaw] = {
+    def errored = ErroredPart(expr.name.value)
+    for {
+      arrows <- EitherT.fromOptionF(
+        // TODO:  Move to purgeDefs here, allow not only arrows
+        //        from parsing, throw errors here
+        D.purgeArrows(expr.name),
+        errored
       )
-    )
-    serviceType <- EitherT.fromOptionF(
-      T.defineServiceType(expr.name, arrowsByName.toSortedMap),
-      Raw.error("Failed to define service type")
-    )
-    arrowsDefs = arrows.map { case (name, _) => name.value -> name }.toNem
-    _ <- EitherT(
-      A.defineService(
-        expr.name,
-        arrowsDefs,
-        defaultId
-      ).map(defined =>
-        Raw
-          .error("Service not created due to validation errors")
-          .asLeft
-          .whenA(!defined)
+      arrowsByName = arrows.map { case (name, arrow) =>
+        name.value -> (name, arrow)
+      }.toNem
+      defaultId <- expr.id.traverse(id =>
+        EitherT.fromOptionF(
+          V.valueToStringRaw(id),
+          errored
+        )
       )
+      serviceType <- EitherT.fromOptionF(
+        T.defineServiceType(expr.name, arrowsByName.toSortedMap),
+        errored
+      )
+      arrowsDefs = arrows.map { case (name, _) => name.value -> name }.toNem
+      _ <- EitherT(
+        A.defineService(
+          expr.name,
+          arrowsDefs,
+          defaultId
+        ).map(defined =>
+          errored.asLeft
+            .whenA(!defined)
+        )
+      )
+    } yield ServiceRaw(
+      expr.name.value,
+      serviceType,
+      defaultId
     )
-  } yield ServiceRaw(
-    expr.name.value,
-    serviceType,
-    defaultId
-  )
+  }
 
   def program[Alg[_]: Monad](using
     A: AbilitiesAlgebra[S, Alg],

--- a/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/ServiceSem.scala
@@ -37,13 +37,13 @@ class ServiceSem[S[_]](val expr: ServiceExpr[S]) extends AnyVal {
         defaultId <- expr.id.traverse(id => OptionT(V.valueToStringRaw(id)))
         serviceType <- OptionT(T.defineServiceType(expr.name, arrowsByName.toSortedMap))
         arrowsDefs = arrows.map { case (name, _) => name.value -> name }.toNem
-        _ <- OptionT.whenM(
+        _ <- OptionT.withFilterF(
           A.defineService(
             expr.name,
             arrowsDefs,
             defaultId
           )
-        )(().pure[Alg])
+        )
       } yield ServiceRaw(
         expr.name.value,
         serviceType,

--- a/semantics/src/main/scala/aqua/semantics/expr/func/FuncSem.scala
+++ b/semantics/src/main/scala/aqua/semantics/expr/func/FuncSem.scala
@@ -1,6 +1,6 @@
 package aqua.semantics.expr.func
 
-import aqua.raw.Raw
+import aqua.raw.{ErroredPart, Raw}
 import aqua.raw.arrow.{ArrowRaw, FuncRaw}
 import aqua.parser.expr.FuncExpr
 import aqua.parser.lexer.Arg
@@ -22,7 +22,7 @@ class FuncSem[S[_]](val expr: FuncExpr[S]) extends AnyVal {
         N.defineArrow(expr.name, arrow.`type`, isRoot = true) as FuncRaw(expr.name.value, arrow)
 
       case _ =>
-        Raw.error("Func must continue with an arrow definition").pure[Alg]
+        ErroredPart(expr.name.value).pure[Alg]
     }
 
 }


### PR DESCRIPTION
## Description
VSCode shows incorrect errors in exported functions

## Proposed Changes
Turn state with errors to `CompileError`

## Implementation Details
Because lsp creates context on errors too, it breaks on finalising headers and shows incorrect error.

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

