### PR TITLE
fix(compiler): Push to stream in closures [LNG-365]

### DIFF
--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -1,16 +1,35 @@
-aqua StreamMapTest declares *
+aqua StreamMapAbilities
 
-export testGetFunc, Srv
+export streamMapAbilityTest
 
-service Srv("baaa"):
-  g() -> string
+service SrvA("a"):
+  call(arrr: []string)
 
-func testGetFunc() -> []string, []string, []string, u32:
-  streamMap: %string
-  key = "key"
-  resEmpty = streamMap.get(key)
-  streamMap <<- key, "first value"
-  resFirst = streamMap.get(key)
-  streamMap <<- key, "second value"
-  resSecond = streamMap.get(key)
-  <- resEmpty, resFirst, resSecond, resSecond.length
+ability Streams:
+  stream: *string
+
+ability Adds:
+  addToStream(s: string)
+
+func addToStreamClosure(str: *string) -> string -> ():
+  cl = func (s: string):
+    SrvA.call(str)
+    str <<- s
+  <- cl
+
+func addTo{Streams}() -> Adds:
+  addStream = addToStreamClosure(Streams.stream)
+  adds = Adds(addToStream = addStream)
+  <- adds
+
+func add{Adds}(s: string, k: string):
+  Adds.addToStream(s)
+
+func streamMapAbilityTest() -> []string:
+  streamBla: *string
+  ab = Streams(stream = streamBla)
+  adds <- addTo{ab}()
+  add{adds}("one", "1")
+  cl = addToStreamClosure(streamBla)
+  cl("two")
+  <- streamBla

--- a/aqua-src/antithesis.aqua
+++ b/aqua-src/antithesis.aqua
@@ -2,34 +2,40 @@ aqua StreamMapAbilities
 
 export streamMapAbilityTest
 
-service SrvA("a"):
-  call(arrr: []string)
-
 ability Streams:
   stream: *string
+  map: %string
 
 ability Adds:
   addToStream(s: string)
+  addToMap(k: string, v: string)
 
 func addToStreamClosure(str: *string) -> string -> ():
   cl = func (s: string):
-    SrvA.call(str)
     str <<- s
+  <- cl
+
+func addToMapClosure(str: %string) -> string, string -> ():
+  cl = func (k: string, v: string):
+    str <<- k, v
   <- cl
 
 func addTo{Streams}() -> Adds:
   addStream = addToStreamClosure(Streams.stream)
-  adds = Adds(addToStream = addStream)
+  addMap = addToMapClosure(Streams.map)
+  adds = Adds(addToStream = addStream, addToMap = addMap)
   <- adds
 
 func add{Adds}(s: string, k: string):
   Adds.addToStream(s)
+  Adds.addToMap(k, k)
 
-func streamMapAbilityTest() -> []string:
-  streamBla: *string
-  ab = Streams(stream = streamBla)
+func streamMapAbilityTest() -> []string, []string:
+  stream: *string
+  map: %string
+  ab = Streams(stream = stream, map = map)
   adds <- addTo{ab}()
   add{adds}("one", "1")
-  cl = addToStreamClosure(streamBla)
-  cl("two")
-  <- streamBla
+  add{adds}("two", "2")
+  add{adds}("three", "3")
+  <- stream, map.keys()

--- a/integration-tests/aqua/examples/closureReturnRename.aqua
+++ b/integration-tests/aqua/examples/closureReturnRename.aqua
@@ -1,6 +1,6 @@
 aqua ClosureReturnRename
 
-export lng193Bug
+export lng193Bug, lng365bug
 
 func getClosure(arg: u16, peer: string) -> u16 -> u16:
   on peer:
@@ -16,3 +16,41 @@ func lng193Bug(peer: string, closurePeer: string) -> u16:
     res1 = a(1) + a(2) -- Call two times for 
     res2 = b(3) + b(4) -- bug to appear
   <- res1 + res2
+
+ability Streams:
+  stream: *string
+  map: %string
+
+ability Adds:
+  addToStream(s: string)
+  addToMap(k: string, v: string)
+
+func addToStreamClosure(str: *string) -> string -> ():
+  cl = func (s: string):
+    str <<- s
+  <- cl
+
+func addToMapClosure(str: %string) -> string, string -> ():
+  cl = func (k: string, v: string):
+    str <<- k, v
+  <- cl
+
+func addTo{Streams}() -> Adds:
+  addStream = addToStreamClosure(Streams.stream)
+  addMap = addToMapClosure(Streams.map)
+  adds = Adds(addToStream = addStream, addToMap = addMap)
+  <- adds
+
+func add{Adds}(s: string, k: string):
+  Adds.addToStream(s)
+  Adds.addToMap(k, k)
+
+func lng365bug() -> []string, []string:
+  stream: *string
+  map: %string
+  ab = Streams(stream = stream, map = map)
+  adds <- addTo{ab}()
+  add{adds}("one", "1")
+  add{adds}("two", "2")
+  add{adds}("three", "3")
+  <- stream, map.keys()

--- a/integration-tests/aqua/examples/closureReturnRename.aqua
+++ b/integration-tests/aqua/examples/closureReturnRename.aqua
@@ -1,6 +1,6 @@
 aqua ClosureReturnRename
 
-export lng193Bug, lng365bug
+export lng193Bug, lng365Bug
 
 func getClosure(arg: u16, peer: string) -> u16 -> u16:
   on peer:
@@ -45,7 +45,7 @@ func add{Adds}(s: string, k: string):
   Adds.addToStream(s)
   Adds.addToMap(k, k)
 
-func lng365bug() -> []string, []string:
+func lng365Bug() -> []string, []string:
   stream: *string
   map: %string
   ab = Streams(stream = stream, map = map)

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -141,7 +141,7 @@ import { literalCall } from "../examples/returnLiteralCall.js";
 import { multiReturnCall } from "../examples/multiReturnCall.js";
 import { declareCall } from "../examples/declareCall.js";
 import { genOptions, genOptionsEmptyString } from "../examples/optionsCall.js";
-import { lng193BugCall } from "../examples/closureReturnRename.js";
+import { lng193BugCall, lng365BugCall } from "../examples/closureReturnRename.js";
 import {
   closuresCall,
   multipleClosuresLNG262BugCall,
@@ -1231,6 +1231,12 @@ describe("Testing examples", () => {
     const result = await lng193BugCall();
     expect(result).toEqual(1 + 42 + (2 + 42) + (3 + 42) + (4 + 42));
   }, 20000);
+
+  it("closureReturnRename.aqua bug LNG-365", async () => {
+    const [values, keys] = await lng365BugCall();
+    expect(values).toEqual(["1", "2", "3"]);
+    expect(keys).toEqual(["one", "two", "three"]);
+  });
 
   it("closures.aqua", async () => {
     const closuresResult = await closuresCall();

--- a/integration-tests/src/__test__/examples.spec.ts
+++ b/integration-tests/src/__test__/examples.spec.ts
@@ -1234,8 +1234,8 @@ describe("Testing examples", () => {
 
   it("closureReturnRename.aqua bug LNG-365", async () => {
     const [values, keys] = await lng365BugCall();
-    expect(values).toEqual(["1", "2", "3"]);
-    expect(keys).toEqual(["one", "two", "three"]);
+    expect(values).toEqual(["one", "two", "three"]);
+    expect(keys).toEqual(["1", "2", "3"]);
   });
 
   it("closures.aqua", async () => {

--- a/integration-tests/src/examples/closureReturnRename.ts
+++ b/integration-tests/src/examples/closureReturnRename.ts
@@ -6,3 +6,7 @@ const relays = config.relays;
 export async function lng193BugCall(): Promise<number> {
   return lng193Bug(relays[4].peerId, relays[5].peerId);
 }
+
+export async function lng365BugCall(): Promise<number> {
+  return lng365Bug();
+}

--- a/integration-tests/src/examples/closureReturnRename.ts
+++ b/integration-tests/src/examples/closureReturnRename.ts
@@ -7,6 +7,6 @@ export async function lng193BugCall(): Promise<number> {
   return lng193Bug(relays[4].peerId, relays[5].peerId);
 }
 
-export async function lng365BugCall(): Promise<number> {
+export async function lng365BugCall() {
   return lng365Bug();
 }

--- a/integration-tests/src/examples/closureReturnRename.ts
+++ b/integration-tests/src/examples/closureReturnRename.ts
@@ -1,4 +1,4 @@
-import { lng193Bug } from "../compiled/examples/closureReturnRename.js";
+import { lng193Bug, lng365Bug } from "../compiled/examples/closureReturnRename.js";
 import { config } from "../config.js";
 
 const relays = config.relays;

--- a/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
+++ b/model/raw/src/main/scala/aqua/raw/ops/RawTag.scala
@@ -306,7 +306,10 @@ case class ClosureTag(
   override def renameExports(map: Map[String, String]): RawTag =
     copy(func =
       func.copy(
-        name = map.getOrElse(func.name, func.name)
+        name = map.getOrElse(func.name, func.name),
+        arrow = func.arrow.copy(
+          body = func.arrow.body.map(_.renameExports(map))
+        )
       )
     )
 


### PR DESCRIPTION
## Description
This didn't work:
```
func addToStreamClosure(str: *string) -> string -> ():
  cl = func (s: string):
    str <<- s
  <- cl

func addToStream() -> []string:
  stream: *string
  cl = addToStreamClosure(stream)
  cl("one")
  <- stream
```
because `str` hasn't been renamed in inliner.

## Proposed Changes
rename exports of closure body on `renameExports`

## Checklist
- [x] Corresponding issue has been created and linked in PR title.
- [x] Proposed changes are covered by tests.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [x] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [x] Any questions or concerns have been addressed.

